### PR TITLE
Integrate chDB, add message queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,25 @@ jobs:
     name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
+    env: { chdb_version: v26.5.1-rc.2 }
     steps:
-      - run: pg-start ${{ matrix.pg }}
-      - uses: actions/checkout@v7
-      - run: pg-build-test
+      - name: Start Postgres ${{ matrix.pg }}
+        run: pg-start ${{ matrix.pg }} libkrb5-dev
+      - name: Checkout the Repository
+        uses: actions/checkout@v7
+      - name: Cache chDB
+        id: cache-chdb
+        uses: actions/cache@v6
+        with:
+          key: chdb-${{ env.chdb_version }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            /usr/local/lib/libchdb.so
+            /usr/local/include/chdb.*
+      - name: Install chDB
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | bash' || 'ldconfig' }}
+        env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
+      - run: |
+          ls -lah /usr/local/lib/libchdb.so /usr/local/include/chdb.*
+          md5sum /usr/local/lib/libchdb.so /usr/local/include/chdb.h
+      - name: Test
+        run: pg-build-test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,14 +11,25 @@ jobs:
     name: 🔎 Lint Code
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
-    env: { pg: 19 }
+    env: { pg: 19, chdb_version: v26.5.1-rc.2 }
     steps:
       - name: Install Postgres
-        run: NO_CLUSTER=1 pg-start ${{ env.pg }} clang-tidy bear
+        run: NO_CLUSTER=1 pg-start ${{ env.pg }} libkrb5-dev clang-tidy bear
       - name: Checkout the Repository
         uses: actions/checkout@v7
       - name: Install pre-commit
         run: make debian-install-lint
+      - name: Cache chDB
+        id: cache-chdb
+        uses: actions/cache@v6
+        with:
+          key: chdb-${{ env.chdb_version }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            /usr/local/lib/libchdb.so
+            /usr/local/include/chdb.*
+      - name: Install chDB
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | bash' || 'ldconfig' }}
+        env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
       - name: Add Postgres to Path
         run: echo /usr/lib/postgresql/${{ env.pg }}/bin >> "$GITHUB_PATH"
       - name: Generate compile_commands.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,32 @@ jobs:
     name: Release on GitHub and PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
+    env: { pg: 19, chdb_version: v26.5.1-rc.2 }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
       - name: Start Postgres
-        run: pg-start 19
+        run: pg-start ${{ env.pg }} libkrb5-dev
+      - name: Cache chDB
+        id: cache-chdb
+        uses: actions/cache@v6
+        with:
+          key: chdb-${{ env.chdb_version }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            /usr/local/lib/libchdb.so
+            /usr/local/include/chdb.*
+      - name: Install chDB
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | bash' || 'ldconfig' }}
+        env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
+      - run: |
+          ls -lah /usr/local/lib/libchdb.so /usr/local/include/chdb.*
+          md5sum /usr/local/lib/libchdb.so /usr/local/include/chdb.h
       - name: Bundle the Release
         id: bundle
         run: pgxn-bundle
       - name: Test the Bundle
         run: make dist-test
+      - run: cat /var/log/postgresql/postgresql-${{ env.pg }}-test.log && ldd /usr/local/lib/libchdb.so
       - name: Release on PGXN
         if: startsWith( github.ref, 'refs/tags/v' )
         env:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ EXTVERSION   = $(shell grep -m 1 'default_version' chdb.control | \
 DISTVERSION  = $(shell grep -m 1 '^[[:space:]]\{2\}"version":' META.json | \
                sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",\{0,1\}/\1/')
 
-DATA         = $(wildcard sql/*.sql)
+DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql)
 DOCS         = $(wildcard doc/*.md)
-TESTS        = $(wildcard test/sql/*.sql)
+TESTS        ?= $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 MODULE_big   = $(EXTENSION)
@@ -20,7 +20,7 @@ OBJS = $(subst .c,.o, $(wildcard src/*.c))
 PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
 
 # Clean up generated files.
-EXTRA_CLEAN  = src/version.h sql/$(EXTENSION)--$(EXTVERSION).sql src/bgw/chdb_bgw$(DLSUFFIX)
+EXTRA_CLEAN  = src/version.h sql/$(EXTENSION)--$(EXTVERSION).sql src/bgw/chdb_bgw.* src/bgw/worker.o src/bgw/worker.bc
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ env PG_CONFIG=/path/to/pg_config make && make installcheck && make install
 If you encounter an error such as:
 
 ```
+worker.c:1:10: fatal error: 'chdb.h' file not found
+```
+
+You either need to install [chDB] or tell the compiler where to find it.
+If, for example, you installed it via the [lib.chdb.io] shell script, point to
+`/usr/local`:
+
+``` sh
+make CFLAGS=-I/usr/local/include \
+     LDFLAGS=-L/usr/local/lib
+```
+
+If you encounter an error such as:
+
+```
 ERROR:  must be owner of database regression
 ```
 
@@ -93,8 +108,6 @@ Dependencies
 
 The `chdb` extension requires PostgreSQL 14 or higher and the [chDB] library.
 
-  [chDB]: https://clickhouse.com/chdb "chDB - fast, reliable, and scalable in-process database"
-
 Author
 ------
 
@@ -104,3 +117,7 @@ Copyright
 ---------
 
 Copyright (c) 2026, ClickHouse
+
+  [chDB]: https://clickhouse.com/chdb
+    "chDB - fast, reliable, and scalable in-process database"
+  [lib.chdb.io]: https://lib.chdb.io "curl -sL https://lib.chdb.io | bash"

--- a/src/bgw/Makefile
+++ b/src/bgw/Makefile
@@ -1,6 +1,8 @@
-MODULE_big = chdb_bgw
-OBJS = $(subst .c,.o, $(wildcard *.c))
-PG_CONFIG ?= pg_config
+MODULE_big   = chdb_bgw
+OBJS 		 = $(subst .c,.o, $(wildcard *.c))
 PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
+PG_LDFLAGS   = -lchdb
+PG_CONFIG   ?= pg_config
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -1,4 +1,4 @@
-
+#include "chdb.h"
 #include "postgres.h"
 
 /* These are always necessary for a bgworker */
@@ -9,7 +9,11 @@
 
 /* these headers are used by this particular worker's code */
 #include "access/xact.h"
+#include "libpq/libpq.h"
+#include "libpq/pqmq.h"
 #include "storage/dsm.h"
+#include "storage/ipc.h"
+#include "storage/proc.h"
 #include "storage/shm_toc.h"
 #include "tcop/utility.h"
 #include "utils/memutils.h"
@@ -74,6 +78,8 @@ chdb_bgw_main(Datum main_arg) {
     memcpy(&ctx->role_id, p, sizeof(Oid));
     p += sizeof(Oid);
     memcpy(&ctx->scheme, p, sizeof(scheme));
+    p += sizeof(scheme);
+    memcpy(&ctx->is_from, p, sizeof(bool));
 
     /* Assemble the rest of the context from shared memory. */
     ctx->schema            = shm_toc_lookup(toc, CHDB_KEY_SCHEMA, false);
@@ -89,6 +95,22 @@ chdb_bgw_main(Datum main_arg) {
     ctx->extra_credentials = shm_toc_lookup(toc, CHDB_KEY_EXTRA_CREDENTIALS, false);
 
     /*
+     * Now we can find and attach to the error queue provided for us.  That's
+     * good, because until we do that, any errors that happen here will not be
+     * reported back to the process that requested that this worker be
+     * launched.
+     */
+    shm_mq* mq = shm_toc_lookup(toc, CHDB_KEY_ERROR_QUEUE, false);
+    shm_mq_set_sender(mq, MyProc);
+    shm_mq_handle* mqh = shm_mq_attach(mq, seg, NULL);
+    pq_redirect_to_shm_mq(seg, mqh);
+
+    /*
+     * Hooray! Primary initialization is complete.  Now, we need to set up our
+     * backend-local state to match the original backend.
+     */
+
+    /*
      * Connect to the database. We skip connection authorization checks,
      * because the creator of the worker always passes the current role.
      */
@@ -101,14 +123,33 @@ chdb_bgw_main(Datum main_arg) {
 #endif
     );
 
+    /*
+     * Connect to chDB. It will use a temporary directory that it cleans up
+     * upon exit.
+     */
+    chdb_connection* conn = chdb_connect(1, (char*[]){ "chdb" });
+
+    if (!conn) {
+        ereport(
+            ERROR,
+            errcode(ERRCODE_CONNECTION_FAILURE),
+            errmsg("unable to connect to chDB")
+        );
+    }
+
     elog(
-        LOG,
-        "%s initialized COPY %s.%s %s",
+        NOTICE,
+        "%s initialized COPY %s.%s %s %s",
         MyBgworkerEntry->bgw_name,
         ctx->schema,
         ctx->table,
+        ctx->is_from ? "FROM" : "TO",
         ctx->url
     );
 
     /* Do the work. */
+
+    /* Report success and exit. */
+    pq_putmessage(PqMsg_Terminate, NULL, 0);
+    proc_exit(0);
 }

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -1,22 +1,41 @@
-
 #ifndef CHDB_WORKER_H
 #define CHDB_WORKER_H
+
+#if PG_VERSION_NUM >= 170000
+#include "libpq/protocol.h"
+#else
+#define PqMsg_Terminate 'X'
+#define PqMsg_ErrorResponse 'E'
+#define PqMsg_NoticeResponse 'N'
+#endif
 
 /* Identifier for shared memory segments used by this extension. */
 #define CHDB_SHM_MAGIC 0x49af4fb3
 
+/*
+ * We don't want to waste a lot of memory on an error queue which, most of the
+ * time, will process only a handful of small messages. However, it is
+ * desirable to make it large enough that a typical ClickHouse error can be
+ * sent without blocking. That way, a worker that errors out can write the
+ * whole message into the queue and terminate without waiting for the user
+ * backend.
+ */
+#define CHDB_ERROR_QUEUE_SIZE 16384
+
 /* Magic numbers for chDB state sharing .*/
-#define CHDB_KEY_SCHEMA UINT64CONST(0xB000000000000004)
-#define CHDB_KEY_TABLE UINT64CONST(0xB000000000000005)
-#define CHDB_KEY_URL UINT64CONST(0xB000000000000006)
-#define CHDB_KEY_ACCESS_KEY UINT64CONST(0xB000000000000007)
-#define CHDB_KEY_ACCESS_SECRET UINT64CONST(0xB000000000000008)
-#define CHDB_KEY_SESSION_TOKEN UINT64CONST(0xB000000000000009)
-#define CHDB_KEY_FORMAT UINT64CONST(0xB00000000000000a)
-#define CHDB_KEY_STRUCTURE UINT64CONST(0xB00000000000000b)
-#define CHDB_KEY_COMPRESSION UINT64CONST(0xB00000000000000c)
-#define CHDB_KEY_HEADERS UINT64CONST(0xB00000000000000d)
-#define CHDB_KEY_EXTRA_CREDENTIALS UINT64CONST(0xB00000000000000e)
+#define CHDB_KEY_SCHEMA UINT64CONST(0xB000000000000001)
+#define CHDB_KEY_TABLE UINT64CONST(0xB000000000000002)
+#define CHDB_KEY_URL UINT64CONST(0xB000000000000003)
+#define CHDB_KEY_ACCESS_KEY UINT64CONST(0xB000000000000004)
+#define CHDB_KEY_ACCESS_SECRET UINT64CONST(0xB000000000000005)
+#define CHDB_KEY_SESSION_TOKEN UINT64CONST(0xB000000000000006)
+#define CHDB_KEY_FORMAT UINT64CONST(0xB000000000000007)
+#define CHDB_KEY_STRUCTURE UINT64CONST(0xB000000000000008)
+#define CHDB_KEY_COMPRESSION UINT64CONST(0xB000000000000009)
+#define CHDB_KEY_HEADERS UINT64CONST(0xB00000000000000a)
+#define CHDB_KEY_EXTRA_CREDENTIALS UINT64CONST(0xB00000000000000b)
+#define CHDB_KEY_ERROR_QUEUE UINT64CONST(0xB00000000000000c)
+#define CHDB_NUM_SHM_KEYS 12 /* Must equal highest CHDB_KEY number above. */
 
 typedef enum scheme {
     http_scheme,
@@ -44,6 +63,7 @@ typedef struct chdbCopyContext {
     Oid db_id;
     Oid role_id;
     scheme scheme;
+    bool is_from;
     char* schema;
     char* table;
     char* url;

--- a/src/hook.c
+++ b/src/hook.c
@@ -3,10 +3,13 @@
 
 #include "bgw/worker.h"
 #include "catalog/namespace.h"
+#include "libpq/pqformat.h"
+#include "libpq/pqmq.h"
 #include "miscadmin.h"
 #include "nodes/pg_list.h"
 #include "postmaster/bgworker.h"
 #include "storage/dsm.h"
+#include "storage/proc.h"
 #include "storage/shm_toc.h"
 #include "tcop/cmdtag.h"
 #include "tcop/utility.h"
@@ -39,6 +42,8 @@ scheme
 scheme_for(const char* str);
 static void
 contextualize_options(chdbCopyContext* ctx, List* options);
+void
+ProcessMessages(shm_mq_handle* queue);
 
 /*
  * InitializeUtilityHook hooks chDBProcessUtilityHook into the process utility
@@ -146,9 +151,10 @@ chDBProcessUtilityHook(
                 .role_id = GetAuthenticatedUserId(),
                 // .session_user_id = GetSessionUserId(),
                 // .outer_user_id = GetCurrentRoleId(),
-                .table  = copy->relation->relname,
-                .schema = schema,
-                .url    = copy->filename,
+                .is_from = copy->is_from,
+                .table   = copy->relation->relname,
+                .schema  = schema,
+                .url     = copy->filename,
             };
             contextualize_options(&ctx, copy->options);
             LaunchWorker(&ctx);
@@ -199,15 +205,14 @@ LaunchWorker(chdbCopyContext* ctx) {
     shm_toc_estimate_chunk(&estimator, strlen(ctx->compression) + 1);
     shm_toc_estimate_chunk(&estimator, strlen(ctx->headers) + 1);
     shm_toc_estimate_chunk(&estimator, strlen(ctx->extra_credentials) + 1);
-    shm_toc_estimate_keys(&estimator, 11);
+    shm_toc_estimate_chunk(&estimator, CHDB_ERROR_QUEUE_SIZE);
+    shm_toc_estimate_keys(&estimator, CHDB_NUM_SHM_KEYS);
 
     /* Create the shared memory segment. */
     Size seg_size    = shm_toc_estimate(&estimator);
     dsm_segment* seg = dsm_create(seg_size, 0);
 
-    /*
-     * Copy the context strings into the shared memory segment.
-     */
+    /* Copy the context strings into the shared memory segment. */
     shm_toc* toc = shm_toc_create(CHDB_SHM_MAGIC, dsm_segment_address(seg), seg_size);
 
     char* string_shm = shm_toc_allocate(toc, strlen(ctx->schema) + 1);
@@ -254,6 +259,14 @@ LaunchWorker(chdbCopyContext* ctx) {
     strcpy(string_shm, ctx->extra_credentials);
     shm_toc_insert(toc, CHDB_KEY_EXTRA_CREDENTIALS, string_shm);
 
+    /* Set up the error queue. */
+    shm_mq* err_queue = shm_mq_create(
+        shm_toc_allocate(toc, CHDB_ERROR_QUEUE_SIZE), CHDB_ERROR_QUEUE_SIZE
+    );
+    shm_toc_insert(toc, CHDB_KEY_ERROR_QUEUE, err_queue);
+    shm_mq_set_receiver(err_queue, MyProc);
+    shm_mq_handle* mqh = shm_mq_attach(err_queue, seg, NULL);
+
     /* Create the worker. */
     BackgroundWorker worker;
     memset(&worker, 0, sizeof(worker));
@@ -274,6 +287,8 @@ LaunchWorker(chdbCopyContext* ctx) {
     memcpy(p, &ctx->role_id, sizeof(Oid));
     p += sizeof(Oid);
     memcpy(p, &ctx->scheme, sizeof(scheme));
+    p += sizeof(scheme);
+    memcpy(p, &ctx->is_from, sizeof(bool));
 
     /* Register the worker. */
     BackgroundWorkerHandle* handle;
@@ -287,6 +302,9 @@ LaunchWorker(chdbCopyContext* ctx) {
             errhint("You might need to increase max_worker_processes.")
         );
     }
+
+    /* Associate this worker with the message queue. */
+    shm_mq_set_handle(mqh, handle);
 
     /* Wait for the background worker to start */
     pid_t pid;
@@ -312,6 +330,68 @@ LaunchWorker(chdbCopyContext* ctx) {
     Assert(status == BGWH_STARTED);
 
     /* Wait for it to finish. */
+    PG_TRY();
+    { ProcessMessages(mqh); }
+    PG_FINALLY();
+    { dsm_detach(seg); }
+    PG_END_TRY();
+
     WaitForBackgroundWorkerShutdown(handle);
-    dsm_detach(seg);
+}
+
+/*
+ * ProcessMessages consumes all messages from queue until it finishes. If it
+ * reads an error message it throws the error. Otherwise it returns once the
+ * queue has been drained.
+ */
+void
+ProcessMessages(shm_mq_handle* queue) {
+    Size msg_len;
+    void* data;
+    StringInfoData msg;
+
+    for (;;) {
+        CHECK_FOR_INTERRUPTS();
+
+        shm_mq_result res = shm_mq_receive(queue, &msg_len, &data, false);
+        if (res != SHM_MQ_SUCCESS) {
+            ereport(
+                ERROR,
+                errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+                errmsg("lost connection to chdb worker")
+            );
+        }
+
+        initStringInfo(&msg);
+        appendBinaryStringInfo(&msg, data, msg_len);
+        int msg_type = pq_getmsgbyte(&msg);
+
+        switch (msg_type) {
+        case PqMsg_ErrorResponse:
+        case PqMsg_NoticeResponse: {
+            /* Read in the error and throw it. */
+            ErrorData err;
+            pq_parse_errornotice(&msg, &err);
+
+            /* Death of a worker isn't enough justification for suicide. */
+            err.elevel = Min(err.elevel, ERROR);
+
+            /* Clean up and rethrow error or print notice. */
+            pfree(msg.data);
+            ThrowErrorData(&err);
+            break;
+        }
+        case PqMsg_Terminate:
+            /* Successful termination. */
+            pfree(msg.data);
+            return;
+
+        default:
+            pfree(msg.data);
+            elog(
+                WARNING, "unexpected message type: %c (%zu bytes)", msg.data[0], msg_len
+            );
+            break;
+        }
+    }
 }

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -24,22 +24,32 @@ COPY logs TO STDOUT;
 4	add_to_cart	/products/shoes
 -- Should intercept known URLs schemas.
 COPY logs TO 's3://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs TO s3://lol
 NOTICE:  COPY logs TO s3('s3://lol')
 COPY logs TO 'http://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs TO http://lol
 NOTICE:  COPY logs TO url('http://lol')
 COPY logs TO 'https://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs TO https://lol
 NOTICE:  COPY logs TO url('https://lol')
 COPY logs TO 'gcs://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs TO gcs://lol
 NOTICE:  COPY logs TO gcs('gcs://lol')
 COPY logs TO 'abs://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs TO abs://lol
 NOTICE:  COPY logs TO azureBlobStorage('abs://lol')
 COPY logs FROM 's3://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs FROM s3://lol
 NOTICE:  COPY logs FROM s3('s3://lol')
 COPY logs FROM 'http://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs FROM http://lol
 NOTICE:  COPY logs FROM url('http://lol')
 COPY logs FROM 'https://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs FROM https://lol
 NOTICE:  COPY logs FROM url('https://lol')
 COPY logs FROM 'gcs://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs FROM gcs://lol
 NOTICE:  COPY logs FROM gcs('gcs://lol')
 COPY logs FROM 'abs://lol';
+NOTICE:  chdb public.logs worker initialized COPY public.logs FROM abs://lol
 NOTICE:  COPY logs FROM azureBlobStorage('abs://lol')


### PR DESCRIPTION
Link to the chDB library in the worker and use it to connect. We expect to use v26.5.1, which adds streaming insert support, but any recent release is fine until we start using that API.

Add the boolean to indicate whether a copy is TO or FROM to the context and use it in the `elog()` currently in the worker. Also update the shared memory keys to start from 1 and not 4.

Add a message queue to the shared memory between the extension and the hook and use it to send messages from the worker to the hook. Read such messages from the hook and print a notice or raise an error. Convert the worker log message to a notice for now to demonstrate that it works.