### PR TITLE
Add `chdbCopyExtra` to simplify `bgw_extra` values

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -72,14 +72,7 @@ chdb_bgw_main(Datum main_arg) {
 
     /* Reconstruct the context, starting with fixed size fields in bgw_extra. */
     chdbCopyContext* ctx = palloc_object(chdbCopyContext);
-    char* p              = MyBgworkerEntry->bgw_extra;
-    memcpy(&ctx->db_id, p, sizeof(Oid));
-    p += sizeof(Oid);
-    memcpy(&ctx->role_id, p, sizeof(Oid));
-    p += sizeof(Oid);
-    memcpy(&ctx->scheme, p, sizeof(scheme));
-    p += sizeof(scheme);
-    memcpy(&ctx->is_from, p, sizeof(bool));
+    memcpy(&ctx->extra, MyBgworkerEntry->bgw_extra, sizeof(chdbCopyExtra));
 
     /* Assemble the rest of the context from shared memory. */
     ctx->schema            = shm_toc_lookup(toc, CHDB_KEY_SCHEMA, false);
@@ -115,8 +108,8 @@ chdb_bgw_main(Datum main_arg) {
      * because the creator of the worker always passes the current role.
      */
     BackgroundWorkerInitializeConnectionByOid(
-        ctx->db_id,
-        ctx->role_id,
+        ctx->extra.db_id,
+        ctx->extra.role_id,
         BGWORKER_BYPASS_ALLOWCONN
 #if PG_VERSION_NUM >= 170000
             | BGWORKER_BYPASS_ROLELOGINCHECK
@@ -143,7 +136,7 @@ chdb_bgw_main(Datum main_arg) {
         MyBgworkerEntry->bgw_name,
         ctx->schema,
         ctx->table,
-        ctx->is_from ? "FROM" : "TO",
+        ctx->extra.is_from ? "FROM" : "TO",
         ctx->url
     );
 

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -37,6 +37,7 @@
 #define CHDB_KEY_ERROR_QUEUE UINT64CONST(0xB00000000000000c)
 #define CHDB_NUM_SHM_KEYS 12 /* Must equal highest CHDB_KEY number above. */
 
+/* URL schemes that the COPY hook understands. */
 typedef enum scheme {
     http_scheme,
     https_scheme,
@@ -46,6 +47,7 @@ typedef enum scheme {
     no_scheme, /* Must be last.*/
 } scheme;
 
+/* Strings for the URL schemes that the COPY hook understands. */
 static char const* const table_function[5] = {
     [http_scheme]  = "url",
     [https_scheme] = "url",
@@ -54,16 +56,32 @@ static char const* const table_function[5] = {
     [abs_scheme]   = "azureBlobStorage",
 };
 
+/*
+ * The names of the ClickHouse functions that correspond to each supported URL
+ * scheme.
+ */
 static char const* const scheme_name[5] = {
     [http_scheme] = "http", [https_scheme] = "https", [s3_scheme] = "s3",
     [gcs_scheme] = "gcs",   [abs_scheme] = "abs",
 };
 
-typedef struct chdbCopyContext {
+/*
+ * Fixed-size context data for chdbCopyContext. Must not exceed BGW_EXTRALEN.
+ * An assertion in hook.c ensures as much.
+ */
+typedef struct chdbCopyExtra {
     Oid db_id;
     Oid role_id;
     scheme scheme;
     bool is_from;
+} chdbCopyExtra;
+
+/*
+ * Contextual data from a COPY command assembled by hook.c and read into
+ * bgw/worker.c.
+ */
+typedef struct chdbCopyContext {
+    chdbCopyExtra extra;
     char* schema;
     char* table;
     char* url;

--- a/src/hook.c
+++ b/src/hook.c
@@ -146,12 +146,14 @@ chDBProcessUtilityHook(
                                      RangeVarGetRelid(copy->relation, NoLock, true)
                                  ));
             chdbCopyContext ctx = {
-                .scheme  = scheme,
-                .db_id   = MyDatabaseId,
-                .role_id = GetAuthenticatedUserId(),
-                // .session_user_id = GetSessionUserId(),
-                // .outer_user_id = GetCurrentRoleId(),
-                .is_from = copy->is_from,
+                .extra = {
+                    .scheme  = scheme,
+                    .db_id   = MyDatabaseId,
+                    .role_id = GetAuthenticatedUserId(),
+                    .is_from = copy->is_from
+                    // .session_user_id = GetSessionUserId(),
+                    // .outer_user_id = GetCurrentRoleId(),
+                 },
                 .table   = copy->relation->relname,
                 .schema  = schema,
                 .url     = copy->filename,
@@ -281,14 +283,11 @@ LaunchWorker(chdbCopyContext* ctx) {
     worker.bgw_notify_pid = MyProcPid;
 
     /* Send the fixed size values via bgw_extra. */
-    char* p = worker.bgw_extra;
-    memcpy(p, &ctx->db_id, sizeof(Oid));
-    p += sizeof(Oid);
-    memcpy(p, &ctx->role_id, sizeof(Oid));
-    p += sizeof(Oid);
-    memcpy(p, &ctx->scheme, sizeof(scheme));
-    p += sizeof(scheme);
-    memcpy(p, &ctx->is_from, sizeof(bool));
+    StaticAssertDecl(
+        sizeof(struct chdbCopyExtra) <= BGW_EXTRALEN,
+        "chdbCopyExtra is to large to fix into BackgroundWorker.bgw_extra"
+    );
+    memcpy(worker.bgw_extra, &ctx->extra, sizeof(chdbCopyExtra));
 
     /* Register the worker. */
     BackgroundWorkerHandle* handle;


### PR DESCRIPTION
Replace the assigning and parsing of individual values of fixed size in `bgw_extra` with a struct that holds them all. This allows a single copy to and from `bgw_extra` and allows for easier changing of the fixed size values in the future. Include an assertion to ensure it never exceeds `BGW_EXTRALEN`. Thanks @serprex for the suggestion.