### PR TITLE
Assemble ClickHouse queries

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -30,6 +30,8 @@ PG_MODULE_MAGIC;
 
 PGDLLEXPORT void
 chdb_bgw_main(Datum main_arg);
+size_t
+make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values);
 
 void
 chdb_bgw_main(Datum main_arg) {
@@ -75,17 +77,15 @@ chdb_bgw_main(Datum main_arg) {
     memcpy(&ctx->extra, MyBgworkerEntry->bgw_extra, sizeof(chdbCopyExtra));
 
     /* Assemble the rest of the context from shared memory. */
-    ctx->schema            = shm_toc_lookup(toc, CHDB_KEY_SCHEMA, false);
-    ctx->table             = shm_toc_lookup(toc, CHDB_KEY_TABLE, false);
-    ctx->url               = shm_toc_lookup(toc, CHDB_KEY_URL, false);
-    ctx->access_key        = shm_toc_lookup(toc, CHDB_KEY_ACCESS_KEY, false);
-    ctx->access_secret     = shm_toc_lookup(toc, CHDB_KEY_ACCESS_SECRET, false);
-    ctx->session_token     = shm_toc_lookup(toc, CHDB_KEY_SESSION_TOKEN, false);
-    ctx->format            = shm_toc_lookup(toc, CHDB_KEY_FORMAT, false);
-    ctx->structure         = shm_toc_lookup(toc, CHDB_KEY_STRUCTURE, false);
-    ctx->compression       = shm_toc_lookup(toc, CHDB_KEY_COMPRESSION, false);
-    ctx->headers           = shm_toc_lookup(toc, CHDB_KEY_HEADERS, false);
-    ctx->extra_credentials = shm_toc_lookup(toc, CHDB_KEY_EXTRA_CREDENTIALS, false);
+    ctx->schema        = shm_toc_lookup(toc, CHDB_KEY_SCHEMA, false);
+    ctx->table         = shm_toc_lookup(toc, CHDB_KEY_TABLE, false);
+    ctx->url           = shm_toc_lookup(toc, CHDB_KEY_URL, false);
+    ctx->access_key    = shm_toc_lookup(toc, CHDB_KEY_ACCESS_KEY, false);
+    ctx->access_secret = shm_toc_lookup(toc, CHDB_KEY_ACCESS_SECRET, false);
+    ctx->session_token = shm_toc_lookup(toc, CHDB_KEY_SESSION_TOKEN, false);
+    ctx->format        = shm_toc_lookup(toc, CHDB_KEY_FORMAT, false);
+    ctx->structure     = shm_toc_lookup(toc, CHDB_KEY_STRUCTURE, false);
+    ctx->compression   = shm_toc_lookup(toc, CHDB_KEY_COMPRESSION, false);
 
     /*
      * Now we can find and attach to the error queue provided for us.  That's
@@ -130,19 +130,105 @@ chdb_bgw_main(Datum main_arg) {
         );
     }
 
-    elog(
-        NOTICE,
-        "%s initialized COPY %s.%s %s %s",
-        MyBgworkerEntry->bgw_name,
-        ctx->schema,
-        ctx->table,
-        ctx->extra.is_from ? "FROM" : "TO",
-        ctx->url
-    );
+    /* Assemble the ClickHouse query. */
+    StringInfoData ch_query;
+    char* names[CHDB_MAX_TABLEFUNC_ARGS];
+    char* values[CHDB_MAX_TABLEFUNC_ARGS];
+    size_t param_count;
+    initStringInfo(&ch_query);
+    param_count = make_ch_query(ctx, &ch_query, names, values);
 
-    /* Do the work. */
+    /* Reassemble params for testing. */
+    StringInfoData params;
+    initStringInfo(&params);
+    bool first = true;
+    for (size_t i = 0; i < param_count; i++) {
+        if (!first) {
+            appendStringInfoString(&params, ", ");
+        }
+        appendStringInfo(&params, "%s: \"%s\"", names[i], values[i]);
+        first = false;
+    }
+
+    elog(NOTICE, "QUERY: %s\nPARAMS: %s", ch_query.data, params.data);
 
     /* Report success and exit. */
     pq_putmessage(PqMsg_Terminate, NULL, 0);
     proc_exit(0);
+}
+
+/* Convenience constant function to append a parameter to a query. */
+#define PARAM(format, name, val)                                                       \
+    Assert(i + 1 <= CHDB_MAX_TABLEFUNC_ARGS);                                          \
+    appendStringInfoString(query, format);                                             \
+    names[i]  = name;                                                                  \
+    values[i] = val;                                                                   \
+    i++;
+
+size_t
+make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values) {
+    /* Start the query. */
+    appendStringInfo(
+        query,
+        "%s %s(",
+        ctx->extra.is_from ? "SELECT * FROM" : "INSERT INTO FUNCTION",
+        table_function[ctx->extra.scheme]
+    );
+
+    size_t i = 0;
+    /* First parameter: the base query. */
+    if (ctx->extra.scheme != abs_scheme) {
+        PARAM("{url:String}", "url", ctx->url);
+    }
+
+    switch (ctx->extra.scheme) {
+    case s3_scheme:
+    case gcs_scheme:
+        /*
+         * https://clickhouse.com/docs/sql-reference/table-functions/s3#syntax
+         * https://clickhouse.com/docs/sql-reference/table-functions/gcs#syntax
+         */
+
+        if (ctx->access_key[0] != '\0') {
+            Assert(i + 2 <= CHDB_MAX_TABLEFUNC_ARGS);
+            /* access_key implies access secret and maybe s3 session_token. */
+            PARAM(", {access_key:String}", "access_key", ctx->access_key);
+            PARAM(", {access_secret:String}", "access_secret", ctx->access_secret);
+            if (ctx->session_token[0] != '\0' && ctx->extra.scheme == s3_scheme) {
+                PARAM(", {session_token:String}", "session_token", ctx->session_token);
+            }
+        }
+
+        /* Append remaining arguments. */
+        if (ctx->compression[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+            PARAM(", {structure:String}", "structure", ctx->structure);
+            PARAM(", {compression:String}", "compression", ctx->compression);
+        } else if (ctx->structure[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+            PARAM(", {structure:String}", "structure", ctx->structure);
+        } else if (ctx->format[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+        }
+        break;
+    case http_scheme:
+    case https_scheme:
+        /* https://clickhouse.com/docs/sql-reference/table-functions/url#syntax */
+        if (ctx->structure[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+            PARAM(", {structure:String}", "structure", ctx->structure);
+        } else if (ctx->format[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+        }
+        break;
+    case abs_scheme:
+        /* TODO, requires parsing URL. */
+    default:
+        elog(ERROR, "unsupported URL scheme %d", ctx->extra.scheme);
+        break;
+    }
+
+    appendStringInfoChar(query, ')');
+
+    return i;
 }

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -33,7 +33,7 @@
 #define CHDB_KEY_STRUCTURE UINT64CONST(0xB000000000000008)
 #define CHDB_KEY_COMPRESSION UINT64CONST(0xB000000000000009)
 #define CHDB_KEY_HEADERS UINT64CONST(0xB00000000000000a)
-#define CHDB_KEY_EXTRA_CREDENTIALS UINT64CONST(0xB00000000000000b)
+#define CHDB_KEY_EXTRA_CREDS UINT64CONST(0xB00000000000000b)
 #define CHDB_KEY_ERROR_QUEUE UINT64CONST(0xB00000000000000c)
 #define CHDB_NUM_SHM_KEYS 12 /* Must equal highest CHDB_KEY number above. */
 
@@ -91,8 +91,9 @@ typedef struct chdbCopyContext {
     char* format;
     char* structure;
     char* compression;
-    char* headers;
-    char* extra_credentials;
 } chdbCopyContext;
+
+/* URL + number of options (char* fields other than schema and table). */
+#define CHDB_MAX_TABLEFUNC_ARGS 7
 
 #endif /* CHDB_WORKER_H */

--- a/src/hook.c
+++ b/src/hook.c
@@ -1,7 +1,6 @@
 
 #include "postgres.h"
 
-#include "bgw/worker.h"
 #include "catalog/namespace.h"
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
@@ -16,6 +15,8 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+
+#include "bgw/worker.h"
 
 /* previous hook */
 static ProcessUtility_hook_type PrevProcessUtility = NULL;
@@ -78,14 +79,12 @@ scheme_for(const char* str) {
 static void
 contextualize_options(chdbCopyContext* ctx, List* options) {
     ListCell* lc;
-    ctx->access_key        = "";
-    ctx->access_secret     = "";
-    ctx->session_token     = "";
-    ctx->format            = "";
-    ctx->structure         = "";
-    ctx->compression       = "";
-    ctx->headers           = "";
-    ctx->extra_credentials = "";
+    ctx->access_key    = "";
+    ctx->access_secret = "";
+    ctx->session_token = "";
+    ctx->format        = "";
+    ctx->structure     = "";
+    ctx->compression   = "";
 
     foreach (lc, options) {
         DefElem* elem = (DefElem*)lfirst(lc);
@@ -103,14 +102,10 @@ contextualize_options(chdbCopyContext* ctx, List* options) {
             ctx->structure = pval;
         } else if (strcmp(pname, "compression") == 0) {
             ctx->compression = pval;
-        } else if (strcmp(pname, "headers") == 0) {
-            ctx->headers = pval;
-        } else if (strcmp(pname, "extra_credentials") == 0) {
-            ctx->extra_credentials = pval;
         } else {
             ereport(
-                NOTICE,
-                errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+                WARNING,
+                errcode(ERRCODE_WARNING),
                 errmsg("chdb does not support COPY option %s", pname)
             );
         }
@@ -205,8 +200,6 @@ LaunchWorker(chdbCopyContext* ctx) {
     shm_toc_estimate_chunk(&estimator, strlen(ctx->format) + 1);
     shm_toc_estimate_chunk(&estimator, strlen(ctx->structure) + 1);
     shm_toc_estimate_chunk(&estimator, strlen(ctx->compression) + 1);
-    shm_toc_estimate_chunk(&estimator, strlen(ctx->headers) + 1);
-    shm_toc_estimate_chunk(&estimator, strlen(ctx->extra_credentials) + 1);
     shm_toc_estimate_chunk(&estimator, CHDB_ERROR_QUEUE_SIZE);
     shm_toc_estimate_keys(&estimator, CHDB_NUM_SHM_KEYS);
 
@@ -252,14 +245,6 @@ LaunchWorker(chdbCopyContext* ctx) {
     string_shm = shm_toc_allocate(toc, strlen(ctx->compression) + 1);
     strcpy(string_shm, ctx->compression);
     shm_toc_insert(toc, CHDB_KEY_COMPRESSION, string_shm);
-
-    string_shm = shm_toc_allocate(toc, strlen(ctx->headers) + 1);
-    strcpy(string_shm, ctx->headers);
-    shm_toc_insert(toc, CHDB_KEY_HEADERS, string_shm);
-
-    string_shm = shm_toc_allocate(toc, strlen(ctx->extra_credentials) + 1);
-    strcpy(string_shm, ctx->extra_credentials);
-    shm_toc_insert(toc, CHDB_KEY_EXTRA_CREDENTIALS, string_shm);
 
     /* Set up the error queue. */
     shm_mq* err_queue = shm_mq_create(

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -24,32 +24,79 @@ COPY logs TO STDOUT;
 4	add_to_cart	/products/shoes
 -- Should intercept known URLs schemas.
 COPY logs TO 's3://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs TO s3://lol
+NOTICE:  QUERY: INSERT INTO FUNCTION s3({url:String})
+PARAMS: url: "s3://lol"
 NOTICE:  COPY logs TO s3('s3://lol')
 COPY logs TO 'http://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs TO http://lol
+NOTICE:  QUERY: INSERT INTO FUNCTION url({url:String})
+PARAMS: url: "http://lol"
 NOTICE:  COPY logs TO url('http://lol')
 COPY logs TO 'https://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs TO https://lol
+NOTICE:  QUERY: INSERT INTO FUNCTION url({url:String})
+PARAMS: url: "https://lol"
 NOTICE:  COPY logs TO url('https://lol')
 COPY logs TO 'gcs://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs TO gcs://lol
+NOTICE:  QUERY: INSERT INTO FUNCTION gcs({url:String})
+PARAMS: url: "gcs://lol"
 NOTICE:  COPY logs TO gcs('gcs://lol')
 COPY logs TO 'abs://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs TO abs://lol
-NOTICE:  COPY logs TO azureBlobStorage('abs://lol')
+ERROR:  unsupported URL scheme 4
 COPY logs FROM 's3://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs FROM s3://lol
+NOTICE:  QUERY: SELECT * FROM s3({url:String})
+PARAMS: url: "s3://lol"
 NOTICE:  COPY logs FROM s3('s3://lol')
 COPY logs FROM 'http://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs FROM http://lol
+NOTICE:  QUERY: SELECT * FROM url({url:String})
+PARAMS: url: "http://lol"
 NOTICE:  COPY logs FROM url('http://lol')
 COPY logs FROM 'https://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs FROM https://lol
+NOTICE:  QUERY: SELECT * FROM url({url:String})
+PARAMS: url: "https://lol"
 NOTICE:  COPY logs FROM url('https://lol')
 COPY logs FROM 'gcs://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs FROM gcs://lol
+NOTICE:  QUERY: SELECT * FROM gcs({url:String})
+PARAMS: url: "gcs://lol"
 NOTICE:  COPY logs FROM gcs('gcs://lol')
 COPY logs FROM 'abs://lol';
-NOTICE:  chdb public.logs worker initialized COPY public.logs FROM abs://lol
-NOTICE:  COPY logs FROM azureBlobStorage('abs://lol')
+ERROR:  unsupported URL scheme 4
+COPY logs FROM 's3://lol.parquet' (
+    access_key 'key',
+    access_secret 'secret',
+    session_token 'big fat token',
+    format 'parquet',
+    structure 'id Int64',
+    compression 'lz4'
+);
+NOTICE:  QUERY: SELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String})
+PARAMS: url: "s3://lol.parquet", access_key: "key", access_secret: "secret", session_token: "big fat token", format: "parquet", structure: "id Int64", compression: "lz4"
+NOTICE:  COPY logs FROM s3('s3://lol.parquet')
+COPY logs TO 'gcs://lol.parquet' (
+    ACCESS_KEY 'gcs_key',
+    ACCESS_SECRET 'gcs_secret',
+    STRUCTURE 'id UInt64',
+    compression 'snappy'
+);
+NOTICE:  QUERY: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String})
+PARAMS: url: "gcs://lol.parquet", access_key: "gcs_key", access_secret: "gcs_secret", format: "", structure: "id UInt64", compression: "snappy"
+NOTICE:  COPY logs TO gcs('gcs://lol.parquet')
+COPY logs TO 'gcs://lol.parquet' (
+    ACCESS_KEY 'gcs_key',
+    ACCESS_SECRET 'gcs_secret',
+    STRUCTURE 'id UInt64'
+);
+NOTICE:  QUERY: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String})
+PARAMS: url: "gcs://lol.parquet", access_key: "gcs_key", access_secret: "gcs_secret", format: "", structure: "id UInt64"
+NOTICE:  COPY logs TO gcs('gcs://lol.parquet')
+COPY logs FROM 'https://example.com/data.csv' (
+    FORMAT 'TSVWithNamesAndTypes',
+    STRUCTURE 'id UInt32'
+);
+NOTICE:  QUERY: SELECT * FROM url({url:String}, {format:String}, {structure:String})
+PARAMS: url: "https://example.com/data.csv", format: "TSVWithNamesAndTypes", structure: "id UInt32"
+NOTICE:  COPY logs FROM url('https://example.com/data.csv')
+COPY logs FROM 'https://example.com/data.csv' (
+    STRUCTURE 'id UInt32'
+);
+NOTICE:  QUERY: SELECT * FROM url({url:String}, {format:String}, {structure:String})
+PARAMS: url: "https://example.com/data.csv", format: "", structure: "id UInt32"
+NOTICE:  COPY logs FROM url('https://example.com/data.csv')

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -34,3 +34,34 @@ COPY logs FROM 'http://lol';
 COPY logs FROM 'https://lol';
 COPY logs FROM 'gcs://lol';
 COPY logs FROM 'abs://lol';
+
+COPY logs FROM 's3://lol.parquet' (
+    access_key 'key',
+    access_secret 'secret',
+    session_token 'big fat token',
+    format 'parquet',
+    structure 'id Int64',
+    compression 'lz4'
+);
+
+COPY logs TO 'gcs://lol.parquet' (
+    ACCESS_KEY 'gcs_key',
+    ACCESS_SECRET 'gcs_secret',
+    STRUCTURE 'id UInt64',
+    compression 'snappy'
+);
+
+COPY logs TO 'gcs://lol.parquet' (
+    ACCESS_KEY 'gcs_key',
+    ACCESS_SECRET 'gcs_secret',
+    STRUCTURE 'id UInt64'
+);
+
+COPY logs FROM 'https://example.com/data.csv' (
+    FORMAT 'TSVWithNamesAndTypes',
+    STRUCTURE 'id UInt32'
+);
+
+COPY logs FROM 'https://example.com/data.csv' (
+    STRUCTURE 'id UInt32'
+);


### PR DESCRIPTION
Assemble the insert or select queries for all of the URL schemes except `abs:`, which will require some URL parsing to call `azureBlobStorage()` with its funky signature. Pass the options as parameters and collect the parameter names and values; these will be passed to `chdb_stream_query_with_params()`.

For now, just emit the assembled parameters and query as a NOTICE. Add some more tests to demonstrate the collection of all of the options into parameters.

While at it, rename `extra_credentials` to `extra_creds`, just to make things a little shorter, and use an appropriate error code for the unused option warning.