### PR TITLE
Implement chDB streaming & Azure URL parsing

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -29,12 +29,39 @@ PG_MODULE_MAGIC_EXT(.name = "chdb_bgw", .version = PGCHCB_VERSION);
 PG_MODULE_MAGIC;
 #endif
 
+/*
+ * Decomposition of an Azure URL into the arguments that `azureBlobStorage()`
+ * expects.
+ */
+typedef struct azureURLParts {
+    char* account_url;
+    char* container;
+    char* path;
+} azureURLParts;
+
+/* Main entrypoint for worker execution. */
 PGDLLEXPORT void
 chdb_bgw_main(Datum main_arg);
+
+/* Creates the chDB query for a COPY. */
 size_t
 make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values);
+
+/* Creates the Postgres query for a COPY. */
 void
 make_pg_query(chdbCopyContext* ctx, StringInfo query);
+
+/* Parses `url` into `parts`. */
+static void
+parse_azure_url(char* url, azureURLParts* parts);
+
+static void
+chdb_conn_free(void*);
+
+inline static void
+chdb_conn_free(void* c) {
+    chdb_close_conn((chdb_connection*)c);
+}
 
 void
 chdb_bgw_main(Datum main_arg) {
@@ -133,7 +160,13 @@ chdb_bgw_main(Datum main_arg) {
         );
     }
 
-    /* Assemble the ClickHouse query. */
+    /* Set up a callback to release the connection when we're done. */
+    MemoryContextCallback cleanup = { 0 };
+    cleanup.func                  = chdb_conn_free;
+    cleanup.arg                   = conn;
+    MemoryContextRegisterResetCallback(CurrentMemoryContext, &cleanup);
+
+    /* Assemble the chDB query. */
     StringInfoData ch_query;
     char* names[CHDB_MAX_TABLEFUNC_ARGS];
     char* values[CHDB_MAX_TABLEFUNC_ARGS];
@@ -160,6 +193,144 @@ chdb_bgw_main(Datum main_arg) {
     initStringInfo(&pg_query);
     make_pg_query(ctx, &pg_query);
     elog(NOTICE, "PG QUERY: %s", pg_query.data);
+    const char* error;
+    chdb_result* result;
+
+    /* [Complete List of
+     * Formats](https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table)
+     */
+    if (ctx->extra.is_from) {
+        /* Start streaming the chDB query. */
+        result = chdb_stream_query_with_params(
+            *conn,
+            ch_query.data,
+            "TSV", /* Compatible with COPY's text format */
+            (const char* const*)names,
+            (const char* const*)values,
+            param_count
+        );
+
+        if (!result) {
+            ereport(
+                ERROR,
+                errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                errmsg("error executing chDB query"),
+                errcontext("query: %s", ch_query.data)
+            );
+        }
+
+        /* Check for errors. */
+        if ((error = chdb_result_error(result))) {
+            error = pstrdup(error);
+            chdb_destroy_query_result(result);
+            ereport(
+                ERROR,
+                errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                errmsg("error executing chDB query"),
+                errdetail("%s", error),
+                errcontext("query: %s", ch_query.data)
+            );
+        }
+
+        /* Process chunks. */
+        while (true) {
+            CHECK_FOR_INTERRUPTS();
+            chdb_result* chunk = chdb_stream_fetch_result(*conn, result);
+            if (!chunk) {
+                break;
+            }
+
+            if ((error = chdb_result_error(chunk))) {
+                /* Cut out the request ID line if present. */
+                char* rec_id = strstr(error, "Request ID:");
+                if (rec_id) {
+                    char* end = (char*)error + strlen(error) + 1;
+                    char* c   = rec_id;
+                    while (c < end && *c != '\n') {
+                        c++;
+                    }
+                    if (c < end) {
+                        memmove(rec_id, c + 1, strlen(c + 1) + 1);
+                    }
+                }
+                ereport(
+                    ERROR,
+                    errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                    errmsg("error fetching chDB query result"),
+                    errdetail("%s", error),
+                    errcontext("query: %s", ch_query.data)
+                );
+            }
+
+            /* Check if we have data in this chunk. */
+            size_t chunk_length = chdb_result_length(chunk);
+            if (chunk_length == 0) {
+                chdb_destroy_query_result(chunk);
+                break; /* End of stream */
+            }
+
+            /* Send the chunk to the Postgres table */
+            char* data = chdb_result_buffer(chunk);
+            elog(NOTICE, "CHUNK: %.*s", (int)chdb_result_length(chunk), data);
+            chdb_destroy_query_result(chunk);
+        }
+
+        /* Cleanup streaming query. */
+        chdb_destroy_query_result(result);
+    } else {
+        /* Start the streaming insert. */
+        chdb_insert_stream stream = chdb_stream_insert(*conn, ch_query.data, "TSV");
+
+        /* Check for errors. */
+        if ((error = chdb_stream_insert_error(stream))) {
+            error = pstrdup(error);
+            chdb_destroy_insert_stream(stream);
+            ereport(
+                ERROR,
+                errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                errmsg("error executing chDB query"),
+                errdetail("ERR: %s", error),
+                errcontext("query: %s", ch_query.data)
+            );
+        }
+
+        /* Stream results from Postgres to chDB. */
+        const char* rec = NULL;
+        while ((rec)) {
+            CHECK_FOR_INTERRUPTS();
+            if (chdb_stream_append(stream, rec, strlen(rec)) != CHDBSuccess) {
+                error = pstrdup(chdb_stream_insert_error(stream));
+                chdb_stream_cancel_insert(stream);
+                chdb_destroy_insert_stream(stream);
+                ereport(
+                    ERROR,
+                    errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                    errmsg("error appending to chDB query"),
+                    errdetail("%s", error),
+                    errcontext("query: %s", ch_query.data)
+                );
+            }
+        }
+
+        /* Tell chDB the insert is done. */
+        result = chdb_stream_done(stream);
+        if ((error = chdb_result_error(result))) {
+            error = pstrdup(error);
+            chdb_destroy_query_result(result);
+            chdb_destroy_insert_stream(stream);
+            ereport(
+                ERROR,
+                errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                errmsg("error finishing chDB query"),
+                errdetail("%s", error),
+                errcontext("query: %s", ch_query.data)
+            );
+        }
+
+        /* Cleanup streaming insert. */
+        chdb_destroy_query_result(result);
+        chdb_destroy_insert_stream(stream);
+    }
 
     /* Report success and exit. */
     pq_putmessage(PqMsg_Terminate, NULL, 0);
@@ -174,6 +345,9 @@ chdb_bgw_main(Datum main_arg) {
     values[i] = val;                                                                   \
     i++;
 
+/* Default chDB query settings. */
+static const char settings[] = "date_time_output_format='iso'";
+
 size_t
 make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values) {
     /* Start the query. */
@@ -184,11 +358,14 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         table_function[ctx->extra.scheme]
     );
 
+    /*
+     * TODO: For streaming queries, the buffer is sized to fit one block of
+     * output: each fetch returns up to max_block_size rows (default 65409).
+     * Consider estimating row size and adjusting the batch size accordingly.
+     * Use `SETTINGS max_block_size = N` to set it per-query.
+     */
+
     size_t i = 0;
-    /* First parameter: the base query. */
-    if (ctx->extra.scheme != abs_scheme) {
-        PARAM("{url:String}", "url", ctx->url);
-    }
 
     switch (ctx->extra.scheme) {
     case s3_scheme:
@@ -198,8 +375,19 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
          * https://clickhouse.com/docs/sql-reference/table-functions/gcs#syntax
          */
 
+        /* First parameter: the base URL. */
+        if (ctx->extra.scheme == s3_scheme) {
+            PARAM("{url:String}", "url", ctx->url);
+        } else {
+            char* uri = strstr(ctx->url, "://");
+            if (!uri) {
+                /* Should not happen, validated by the hook. */
+                elog(ERROR, "chdb: malformed GCS URL %s ", ctx->url);
+            }
+            PARAM("{url:String}", "url", psprintf("https%s", uri));
+        }
+
         if (ctx->access_key[0] != '\0') {
-            Assert(i + 2 <= CHDB_MAX_TABLEFUNC_ARGS);
             /* access_key implies access secret and maybe s3 session_token. */
             PARAM(", {access_key:String}", "access_key", ctx->access_key);
             PARAM(", {access_secret:String}", "access_secret", ctx->access_secret);
@@ -208,36 +396,87 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
             }
         }
 
-        /* Append remaining arguments. */
+        /* Append remaining arguments and settings. */
         if (ctx->compression[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
-            PARAM(", {structure:String}", "structure", ctx->structure);
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+            PARAM(
+                ", {structure:String}",
+                "structure",
+                ctx->structure[0] ? ctx->structure : "auto"
+            );
             PARAM(", {compression:String}", "compression", ctx->compression);
         } else if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
             PARAM(", {structure:String}", "structure", ctx->structure);
         } else if (ctx->format[0] != '\0') {
             PARAM(", {format:String}", "format", ctx->format);
         }
+        appendStringInfo(
+            query,
+            ") SETTINGS %s, s3_request_timeout_ms = %u",
+            settings,
+            ctx->extra.timeout
+        );
         break;
     case http_scheme:
     case https_scheme:
         /* https://clickhouse.com/docs/sql-reference/table-functions/url#syntax */
+
+        /* First parameter: the base URL. */
+        PARAM("{url:String}", "url", ctx->url);
+
         if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
             PARAM(", {structure:String}", "structure", ctx->structure);
         } else if (ctx->format[0] != '\0') {
             PARAM(", {format:String}", "format", ctx->format);
         }
+        appendStringInfo(
+            query,
+            ") SETTINGS %s, http_connection_timeout=%u, http_max_tries=1",
+            settings,
+            ctx->extra.timeout / 1000
+        );
         break;
-    case abs_scheme:
-        /* TODO, requires parsing URL. */
+    case abs_scheme: {
+        /*
+         * https://clickhouse.com/docs/sql-reference/table-functions/azureBlobStorage#syntax
+         */
+
+        /* Parse the Azure URL to get the account URL, container, and path. */
+        azureURLParts parts;
+        parse_azure_url(ctx->url, &parts);
+
+        /* Append required args. */
+        PARAM("{url:String}", "url", parts.account_url);
+        PARAM(", {container:String}", "container", parts.container);
+        PARAM(", {path:String}", "path", parts.path);
+        PARAM(", {account_name:String}", "account_name", ctx->access_key);
+        PARAM(", {account_key:String}", "account_key", ctx->access_secret);
+
+        /* Append remaining arguments (different order from the others) and settings. */
+        if (ctx->structure[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+            PARAM(", {compression:String}", "compression", ctx->compression);
+            PARAM(", {structure:String}", "structure", ctx->structure);
+        } else if (ctx->compression[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+            PARAM(", {compression:String}", "compression", ctx->compression);
+        } else if (ctx->format[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+        }
+        appendStringInfo(
+            query,
+            ") SETTINGS %s, azure_request_timeout_ms=%u",
+            settings,
+            ctx->extra.timeout
+        );
+        break;
+    }
     default:
         elog(ERROR, "unsupported URL scheme %d", ctx->extra.scheme);
         break;
     }
-
-    appendStringInfoChar(query, ')');
 
     return i;
 }
@@ -256,4 +495,71 @@ make_pg_query(chdbCopyContext* ctx, StringInfo query) {
         ctx->extra.is_from ? "FROM" : "TO",
         ctx->extra.is_from ? "IN" : "OUT"
     );
+}
+
+/*
+* Decomposition of an Azure URL into the arguments the `azureBlobStorage`
+  engine expects.
+*/
+static void
+parse_azure_url(char* url, azureURLParts* parts) {
+    /*
+     * Based on Azure URL parsing for the url() function in ClickHouse 26.7:
+     * https://github.com/ClickHouse/ClickHouse/blob/0b235b0/src/Storages/StorageURL.cpp#L2016-L2087
+     */
+    char* uri = strstr(url, "://");
+    if (!uri) {
+        /* Should not happen, validated by the hook. */
+        elog(ERROR, "chdb: malformed Azure URL %s ", url);
+    }
+
+    uri += 3;
+
+    /// Split off the query string (a SAS token such as `?sp=...&sig=...`)
+    /// before parsing the host and path.
+    char* query = strchr(uri, '?');
+    if (query) {
+        /* NUL terminate the URL and split off the query. */
+        *query = '\0';
+        query++;
+    }
+
+    /*
+     * `<account>.blob.core.windows.net/<container>/<blob>` or
+     * `<host>/<container>/<blob>`.
+     */
+    char* path = strstr(uri, "/");
+
+    /*
+     * `az://<account>.blob.core.windows.net/<container>/<blob>` or
+     * `azure://<host>/<container>/<blob>`
+     */
+    const char* host = path ? pnstrdup(uri, path - uri) : uri;
+    path             = path ? path + 1 : "";
+
+    char* dot = strchr(host, '.');
+    if (!dot) {
+        ereport(
+            ERROR,
+            errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+            errmsg("chdb: Azure URL missing the storage account host"),
+            errhint("abs://<account>.blob.core.windows.net/<container>/<path>")
+        );
+    }
+
+    parts->account_url =
+        query ? psprintf("https://%s?%s", host, query) : psprintf("https://%s", host);
+    char* slash = strchr(path, '/');
+    parts->container =
+        slash ? pnstrdup(path, slash - path) : pnstrdup(path, strlen(path));
+    parts->path = slash ? slash + 1 : "";
+
+    if (strlen(parts->container) == 0) {
+        ereport(
+            ERROR,
+            errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+            errmsg("chdb: Azure URL missing the container name"),
+            errhint("abs://<account>.blob.core.windows.net/<container>/<path>")
+        );
+    }
 }

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -52,7 +52,7 @@ static char const* const table_function[5] = {
     [http_scheme]  = "url",
     [https_scheme] = "url",
     [s3_scheme]    = "s3",
-    [gcs_scheme]   = "gcs",
+    [gcs_scheme]   = "gcs", /* Alias of s3, but keep it explicit.*/
     [abs_scheme]   = "azureBlobStorage",
 };
 
@@ -74,6 +74,7 @@ typedef struct chdbCopyExtra {
     Oid role_id;
     scheme scheme;
     bool is_from;
+    uint32_t timeout; /* request timeout in milliseconds */
 } chdbCopyExtra;
 
 /*
@@ -93,7 +94,10 @@ typedef struct chdbCopyContext {
     char* compression;
 } chdbCopyContext;
 
-/* URL + number of options (char* fields other than schema and table). */
-#define CHDB_MAX_TABLEFUNC_ARGS 7
+/*
+ * URL + number of options (char* fields other than schema and table) +2 for
+ * Azure URL parsing.
+ */
+#define CHDB_MAX_TABLEFUNC_ARGS 9
 
 #endif /* CHDB_WORKER_H */

--- a/src/hook.c
+++ b/src/hook.c
@@ -1,7 +1,9 @@
 
+
 #include "postgres.h"
 
 #include "catalog/namespace.h"
+#include "commands/defrem.h"
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
 #include "miscadmin.h"
@@ -14,6 +16,10 @@
 #include "tcop/utility.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+
+#ifndef SCNu32
+#include <inttypes.h>
+#endif
 
 #include "bgw/worker.h"
 
@@ -84,28 +90,37 @@ contextualize_options(chdbCopyContext* ctx, List* options) {
     ctx->format        = "";
     ctx->structure     = "";
     ctx->compression   = "";
+    ctx->extra.timeout = 30000; /* Same as ClickHouse. */
 
     foreach (lc, options) {
         DefElem* elem = (DefElem*)lfirst(lc);
-        char* pname   = elem->defname;
-        char* pval    = strVal(elem->arg);
-        if (strcmp(pname, "access_key") == 0) {
-            ctx->access_key = pval;
-        } else if (strcmp(pname, "access_secret") == 0) {
-            ctx->access_secret = pval;
-        } else if (strcmp(pname, "session_token") == 0) {
-            ctx->session_token = pval;
-        } else if (strcmp(pname, "format") == 0) {
-            ctx->format = pval;
-        } else if (strcmp(pname, "structure") == 0) {
-            ctx->structure = pval;
-        } else if (strcmp(pname, "compression") == 0) {
-            ctx->compression = pval;
+        if (strcmp(elem->defname, "access_key") == 0) {
+            ctx->access_key = defGetString(elem);
+        } else if (strcmp(elem->defname, "access_secret") == 0) {
+            ctx->access_secret = defGetString(elem);
+        } else if (strcmp(elem->defname, "session_token") == 0) {
+            ctx->session_token = defGetString(elem);
+        } else if (strcmp(elem->defname, "format") == 0) {
+            ctx->format = defGetString(elem);
+        } else if (strcmp(elem->defname, "structure") == 0) {
+            ctx->structure = defGetString(elem);
+        } else if (strcmp(elem->defname, "compression") == 0) {
+            ctx->compression = defGetString(elem);
+        } else if (strcmp(elem->defname, "timeout") == 0) {
+            uint64_t timeout = defGetInt64(elem);
+            if (timeout < 0) {
+                ereport(
+                    ERROR,
+                    errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                    errmsg("chdb: argument to COPY option \"timeout\" must be a uint32")
+                );
+            }
+            ctx->extra.timeout = (uint32_t)timeout;
         } else {
             ereport(
-                WARNING,
-                errcode(ERRCODE_WARNING),
-                errmsg("chdb does not support COPY option %s", pname)
+                ERROR,
+                errcode(ERRCODE_SYNTAX_ERROR),
+                errmsg("chdb: option \"%s\" not supported", elem->defname)
             );
         }
     }

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -23,89 +23,173 @@ COPY logs TO STDOUT;
 3	PAGE_VIEW	/admin/dashboard
 4	add_to_cart	/products/shoes
 -- Should intercept known URLs schemas.
-COPY logs TO 's3://lol';
-NOTICE:  CH QUERY: INSERT INTO FUNCTION s3({url:String})
-PARAMS: url: "s3://lol"
+COPY logs TO 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: INSERT INTO FUNCTION s3({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+PARAMS: url: "s3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv"
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
-COPY logs TO 'http://lol';
-NOTICE:  CH QUERY: INSERT INTO FUNCTION url({url:String})
-PARAMS: url: "http://lol"
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION s3({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+COPY logs TO 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: INSERT INTO FUNCTION url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv"
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
-COPY logs TO 'https://lol';
-NOTICE:  CH QUERY: INSERT INTO FUNCTION url({url:String})
-PARAMS: url: "https://lol"
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+COPY logs TO 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: INSERT INTO FUNCTION url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv"
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
-COPY logs TO 'gcs://lol';
-NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String})
-PARAMS: url: "gcs://lol"
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+PARAMS: url: "https://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz"
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
-COPY logs TO 'abs://lol';
-ERROR:  unsupported URL scheme 4
-COPY logs FROM 's3://lol';
-NOTICE:  CH QUERY: SELECT * FROM s3({url:String})
-PARAMS: url: "s3://lol"
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION gcs({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv';
+NOTICE:  CH QUERY: INSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000
+PARAMS: url: "https://account.blob.core.windows.net", container: "container", path: "path/to.csv", account_name: "", account_key: ""
+NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000
+COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: SELECT * FROM s3({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+PARAMS: url: "s3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
-COPY logs FROM 'http://lol';
-NOTICE:  CH QUERY: SELECT * FROM url({url:String})
-PARAMS: url: "http://lol"
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
+COPY logs FROM 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: SELECT * FROM url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
-COPY logs FROM 'https://lol';
-NOTICE:  CH QUERY: SELECT * FROM url({url:String})
-PARAMS: url: "https://lol"
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
+COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: SELECT * FROM url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
-COPY logs FROM 'gcs://lol';
-NOTICE:  CH QUERY: SELECT * FROM gcs({url:String})
-PARAMS: url: "gcs://lol"
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
+COPY logs FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+NOTICE:  CH QUERY: SELECT * FROM gcs({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+PARAMS: url: "https://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
-COPY logs FROM 'abs://lol';
-ERROR:  unsupported URL scheme 4
-COPY logs FROM 's3://lol.parquet' (
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
+COPY logs FROM 'abs://account.blob.core.windows.net/container/path/to.csv';
+NOTICE:  CH QUERY: SELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000
+PARAMS: url: "https://account.blob.core.windows.net", container: "container", path: "path/to.csv", account_name: "", account_key: ""
+NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
+ERROR:  error fetching chDB query result
+DETAIL:  Code: 636. DB::Exception: The table structure cannot be extracted from a CSV format file:
+std::exception. Code: 1001, type: Azure::Storage::StorageException, e.what() = 403 The specified account is disabled.
+
+You can specify the structure manually. (CANNOT_EXTRACT_TABLE_STRUCTURE)
+CONTEXT:  query: SELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000
+COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv' (
     access_key 'key',
     access_secret 'secret',
     session_token 'big fat token',
     format 'parquet',
     structure 'id Int64',
-    compression 'lz4'
+    compression 'lz4',
+    timeout 50000
 );
-NOTICE:  CH QUERY: SELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String})
-PARAMS: url: "s3://lol.parquet", access_key: "key", access_secret: "secret", session_token: "big fat token", format: "parquet", structure: "id Int64", compression: "lz4"
+NOTICE:  CH QUERY: SELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 50000
+PARAMS: url: "s3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv", access_key: "key", access_secret: "secret", session_token: "big fat token", format: "parquet", structure: "id Int64", compression: "lz4"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
-COPY logs TO 'gcs://lol.parquet' (
+ERROR:  error fetching chDB query result
+DETAIL:  Code: 499. DB::Exception: Failed to get object info: No response body.. HTTP response code: 403. Please check your AWS credentials and permissions: while reading 'my-test-bucket-768/some_prefix/some_file_1.csv' in bucket 'datasets-documentation' on disk 'StorageS3': While executing ReadFromObjectStorage. (S3_ERROR)
+CONTEXT:  query: SELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 50000
+COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz' (
     ACCESS_KEY 'gcs_key',
     ACCESS_SECRET 'gcs_secret',
     STRUCTURE 'id UInt64',
     compression 'snappy'
 );
-NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String})
-PARAMS: url: "gcs://lol.parquet", access_key: "gcs_key", access_secret: "gcs_secret", format: "", structure: "id UInt64", compression: "snappy"
+NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+PARAMS: url: "https://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz", access_key: "gcs_key", access_secret: "gcs_secret", format: "auto", structure: "id UInt64", compression: "snappy"
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
-COPY logs TO 'gcs://lol.parquet' (
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv' (
+    ACCESS_KEY 'az_key',
+    ACCESS_SECRET 'az_secret',
+    STRUCTURE 'id UInt64',
+    compression 'snappy',
+    format 'CSV',
+    timeout 1000
+);
+NOTICE:  CH QUERY: INSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=1000
+PARAMS: url: "https://account.blob.core.windows.net", container: "container", path: "path/to.csv", account_name: "az_key", account_key: "az_secret", format: "CSV", compression: "snappy", structure: "id UInt64"
+NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=1000
+COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz' (
     ACCESS_KEY 'gcs_key',
     ACCESS_SECRET 'gcs_secret',
     STRUCTURE 'id UInt64'
 );
-NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String})
-PARAMS: url: "gcs://lol.parquet", access_key: "gcs_key", access_secret: "gcs_secret", format: "", structure: "id UInt64"
+NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+PARAMS: url: "https://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz", access_key: "gcs_key", access_secret: "gcs_secret", format: "auto", structure: "id UInt64"
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
-COPY logs FROM 'https://example.com/data.csv' (
-    FORMAT 'TSVWithNamesAndTypes',
-    STRUCTURE 'id UInt32'
+ERROR:  error executing chDB query
+DETAIL:  ERR: Failed to receive table structure
+CONTEXT:  query: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
+COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv' (
+    FORMAT 'CSV',
+    STRUCTURE 'id UInt32, num UInt32, age UInt32'
 );
-NOTICE:  CH QUERY: SELECT * FROM url({url:String}, {format:String}, {structure:String})
-PARAMS: url: "https://example.com/data.csv", format: "TSVWithNamesAndTypes", structure: "id UInt32"
+NOTICE:  CH QUERY: SELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv", format: "CSV", structure: "id UInt32, num UInt32, age UInt32"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
-COPY logs FROM 'https://example.com/data.csv' (
-    STRUCTURE 'id UInt32'
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
+COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv' (
+    STRUCTURE 'id UInt32, num UInt32, age UInt32'
 );
-NOTICE:  CH QUERY: SELECT * FROM url({url:String}, {format:String}, {structure:String})
-PARAMS: url: "https://example.com/data.csv", format: "", structure: "id UInt32"
+NOTICE:  CH QUERY: SELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv", format: "auto", structure: "id UInt32, num UInt32, age UInt32"
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
 CREATE SCHEMA "big deal";
 CREATE TABLE "big deal"."myParts" (
     part_id   BIGINT PRIMARY KEY,
     name      TEXT     NOT NULL
 );
-COPY "big deal"."myParts" TO 'gcs://lol.parquet';
-NOTICE:  CH QUERY: INSERT INTO FUNCTION gcs({url:String})
-PARAMS: url: "gcs://lol.parquet"
-NOTICE:  PG QUERY: COPY "big deal"."myParts" TO STDOUT (FORMAT text);
+COPY "big deal"."myParts" FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+NOTICE:  CH QUERY: SELECT * FROM url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1
+PARAMS: url: "https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv"
+NOTICE:  PG QUERY: COPY "big deal"."myParts" FROM STDIN (FORMAT text);
+NOTICE:  CHUNK: 1	2	3
+3	2	1
+4	5	6
+
+-- Option failure modes.
+COPY logs FROM 's3://thing.csv' (timeout '10');
+ERROR:  timeout requires a numeric value
+COPY logs FROM 's3://thing.csv' (format 22, nope true);
+ERROR:  chdb: option "nope" not supported
+COPY logs FROM 's3://thing.csv' (nonesuch 'hi');
+ERROR:  chdb: option "nonesuch" not supported

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -23,47 +23,57 @@ VALUES (1, 'page_view',   '/users/profile')
 COPY logs TO STDOUT;
 
 -- Should intercept known URLs schemas.
-COPY logs TO 's3://lol';
-COPY logs TO 'http://lol';
-COPY logs TO 'https://lol';
-COPY logs TO 'gcs://lol';
-COPY logs TO 'abs://lol';
+COPY logs TO 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+COPY logs TO 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+COPY logs TO 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv';
 
-COPY logs FROM 's3://lol';
-COPY logs FROM 'http://lol';
-COPY logs FROM 'https://lol';
-COPY logs FROM 'gcs://lol';
-COPY logs FROM 'abs://lol';
+COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+COPY logs FROM 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+COPY logs FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+COPY logs FROM 'abs://account.blob.core.windows.net/container/path/to.csv';
 
-COPY logs FROM 's3://lol.parquet' (
+COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv' (
     access_key 'key',
     access_secret 'secret',
     session_token 'big fat token',
     format 'parquet',
     structure 'id Int64',
-    compression 'lz4'
+    compression 'lz4',
+    timeout 50000
 );
 
-COPY logs TO 'gcs://lol.parquet' (
+COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz' (
     ACCESS_KEY 'gcs_key',
     ACCESS_SECRET 'gcs_secret',
     STRUCTURE 'id UInt64',
     compression 'snappy'
 );
 
-COPY logs TO 'gcs://lol.parquet' (
+COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv' (
+    ACCESS_KEY 'az_key',
+    ACCESS_SECRET 'az_secret',
+    STRUCTURE 'id UInt64',
+    compression 'snappy',
+    format 'CSV',
+    timeout 1000
+);
+
+COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz' (
     ACCESS_KEY 'gcs_key',
     ACCESS_SECRET 'gcs_secret',
     STRUCTURE 'id UInt64'
 );
 
-COPY logs FROM 'https://example.com/data.csv' (
-    FORMAT 'TSVWithNamesAndTypes',
-    STRUCTURE 'id UInt32'
+COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv' (
+    FORMAT 'CSV',
+    STRUCTURE 'id UInt32, num UInt32, age UInt32'
 );
 
-COPY logs FROM 'https://example.com/data.csv' (
-    STRUCTURE 'id UInt32'
+COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv' (
+    STRUCTURE 'id UInt32, num UInt32, age UInt32'
 );
 CREATE SCHEMA "big deal";
 
@@ -72,4 +82,9 @@ CREATE TABLE "big deal"."myParts" (
     name      TEXT     NOT NULL
 );
 
-COPY "big deal"."myParts" TO 'gcs://lol.parquet';
+COPY "big deal"."myParts" FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
+
+-- Option failure modes.
+COPY logs FROM 's3://thing.csv' (timeout '10');
+COPY logs FROM 's3://thing.csv' (format 22, nope true);
+COPY logs FROM 's3://thing.csv' (nonesuch 'hi');


### PR DESCRIPTION
Implement the chDB streaming SELECT and INSERT logic to execute the queries sent to chDB. Just emit SELECT results as a NOTICE for now, and leave the scaffolding for sending INSERT data in a no-op loop for a NULL variable for now. Carefully copy an error message and free all of the chDB allocated memory before raising a Postgres exception, to keep memory management properly separated and clean.

The one bit of funky-ness is stripping out a `Request ID:` line from an error message so that errors are consistent and thus testable.

Set up a memory context callback to release the chDB connection when we exit, whether through an error, interrupt, or normal exit.

Refactor the chDB query generation to use `auto` as the value for otherwise unset `format` and `structure` arguments; encapsulate this behavior in `append_format_structure_compression()`, since the S3, GCS, and ABS functions all handle these two arguments, along with `compression`, in the same way and order.

Speaking of ABS, add `azureURLParts` and `parse_azure_url`, ported from ClickHouse/ClickHouse#106093, to extract the account URL, container name, and storage path from the URL and generate the `azureBlobStorage()` SQL with those parts. Also change the `gcs` URL to `https`, the scheme recognized by `gcs()`.

Add a new `COPY` option, `timeout`, to allow the user to set a request timeout. Defaults to 30s. While at it switch to using the Postgres option parsing functions to ensure we get valid values.

Add the `settings` constant and use it to construct settings for each query, appending those settings required for each function, including the timeout, as it varies for each function.

Update the tests to call real public URLs on S3 and GCS. The `NOTICE`s show that their contents are properly fetched for `COPY FROM` unless the credentials are incorrect; `COPY TO` currently fails because we're not sending any data and because we don't have permission anyway.