### PR TITLE
Use same schemes as ClickHouse 26.7 url() function

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -419,7 +419,6 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         );
         break;
     case http_scheme:
-    case https_scheme:
         /* https://clickhouse.com/docs/sql-reference/table-functions/url#syntax */
 
         /* First parameter: the base URL. */
@@ -543,7 +542,7 @@ parse_azure_url(char* url, azureURLParts* parts) {
             ERROR,
             errcode(ERRCODE_INVALID_PARAMETER_VALUE),
             errmsg("chdb: Azure URL missing the storage account host"),
-            errhint("abs://<account>.blob.core.windows.net/<container>/<path>")
+            errhint("az://<account>.blob.core.windows.net/<container>/<path>")
         );
     }
 
@@ -559,7 +558,7 @@ parse_azure_url(char* url, azureURLParts* parts) {
             ERROR,
             errcode(ERRCODE_INVALID_PARAMETER_VALUE),
             errmsg("chdb: Azure URL missing the container name"),
-            errhint("abs://<account>.blob.core.windows.net/<container>/<path>")
+            errhint("az://<account>.blob.core.windows.net/<container>/<path>")
         );
     }
 }

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -40,29 +40,40 @@
 /* URL schemes that the COPY hook understands. */
 typedef enum scheme {
     http_scheme,
-    https_scheme,
     s3_scheme,
     gcs_scheme,
     abs_scheme,
+    // file_scheme,
+    // hdfs_scheme,
     no_scheme, /* Must be last.*/
 } scheme;
-
-/* Strings for the URL schemes that the COPY hook understands. */
-static char const* const table_function[5] = {
-    [http_scheme]  = "url",
-    [https_scheme] = "url",
-    [s3_scheme]    = "s3",
-    [gcs_scheme]   = "gcs", /* Alias of s3, but keep it explicit.*/
-    [abs_scheme]   = "azureBlobStorage",
-};
 
 /*
  * The names of the ClickHouse functions that correspond to each supported URL
  * scheme.
  */
-static char const* const scheme_name[5] = {
-    [http_scheme] = "http", [https_scheme] = "https", [s3_scheme] = "s3",
-    [gcs_scheme] = "gcs",   [abs_scheme] = "abs",
+static char const* const table_function[] = {
+    [http_scheme] = "url",
+    [s3_scheme]   = "s3",
+    [gcs_scheme]  = "gcs", /* Alias of s3, but keep it explicit.*/
+    [abs_scheme]  = "azureBlobStorage",
+    // [file_scheme] = "file",
+    // [hdfs_scheme] = "hdfs",
+};
+
+/*
+ * Strings for the URL schemes that the COPY hook understands. Same as for the
+ * schemes used for dispatch in the ClickHouse 26.7 `url()` function. Must
+ * allocate one more than the longest list, so that each ends in a NULL.
+ * https://clickhouse.com/docs/sql-reference/table-functions/url#scheme-dispatch
+ */
+static char const* const scheme_name[no_scheme][5] = {
+    [http_scheme] = { "http", "https" },
+    [s3_scheme]   = { "s3" },
+    [gcs_scheme]  = { "gs", "gcs", "oss" },
+    [abs_scheme]  = { "az", "azure", "abfss", "abfs" },
+    // [file_scheme] = { "file", NULL },
+    // [hdfs_scheme] = { "hdfs", NULL },
 };
 
 /*

--- a/src/hook.c
+++ b/src/hook.c
@@ -70,9 +70,11 @@ scheme_for(const char* str) {
             size_t len = ptr - str;
 
             for (size_t sch = http_scheme; sch < no_scheme; sch++) {
-                if (strlen(scheme_name[sch]) == len &&
-                    memcmp(str, scheme_name[sch], len) == 0) {
-                    return sch;
+                for (size_t i = 0; scheme_name[sch][i]; i++) {
+                    if (strlen(scheme_name[sch][i]) == len &&
+                        memcmp(str, scheme_name[sch][i], len) == 0) {
+                        return sch;
+                    }
                 }
             }
         }

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -51,7 +51,7 @@ NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
 ERROR:  error executing chDB query
 DETAIL:  ERR: Failed to receive table structure
 CONTEXT:  query: INSERT INTO FUNCTION gcs({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
-COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv';
+COPY logs TO 'az://account.blob.core.windows.net/container/path/to.csv';
 NOTICE:  CH QUERY: INSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000
 PARAMS: url: "https://account.blob.core.windows.net", container: "container", path: "path/to.csv", account_name: "", account_key: ""
 NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
@@ -90,7 +90,7 @@ NOTICE:  CHUNK: 1	2	3
 3	2	1
 4	5	6
 
-COPY logs FROM 'abs://account.blob.core.windows.net/container/path/to.csv';
+COPY logs FROM 'az://account.blob.core.windows.net/container/path/to.csv';
 NOTICE:  CH QUERY: SELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000
 PARAMS: url: "https://account.blob.core.windows.net", container: "container", path: "path/to.csv", account_name: "", account_key: ""
 NOTICE:  PG QUERY: COPY public.logs FROM STDIN (FORMAT text);
@@ -127,7 +127,7 @@ NOTICE:  PG QUERY: COPY public.logs TO STDOUT (FORMAT text);
 ERROR:  error executing chDB query
 DETAIL:  ERR: Failed to receive table structure
 CONTEXT:  query: INSERT INTO FUNCTION gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000
-COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv' (
+COPY logs TO 'az://account.blob.core.windows.net/container/path/to.csv' (
     ACCESS_KEY 'az_key',
     ACCESS_SECRET 'az_secret',
     STRUCTURE 'id UInt64',

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -27,13 +27,13 @@ COPY logs TO 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_fi
 COPY logs TO 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs TO 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
-COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv';
+COPY logs TO 'az://account.blob.core.windows.net/container/path/to.csv';
 
 COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs FROM 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
-COPY logs FROM 'abs://account.blob.core.windows.net/container/path/to.csv';
+COPY logs FROM 'az://account.blob.core.windows.net/container/path/to.csv';
 
 COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv' (
     access_key 'key',
@@ -52,7 +52,7 @@ COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bu
     compression 'snappy'
 );
 
-COPY logs TO 'abs://account.blob.core.windows.net/container/path/to.csv' (
+COPY logs TO 'az://account.blob.core.windows.net/container/path/to.csv' (
     ACCESS_KEY 'az_key',
     ACCESS_SECRET 'az_secret',
     STRUCTURE 'id UInt64',


### PR DESCRIPTION
Map one or more scheme strings to a single identifier and search each of them in sequence. This allows the `https_scheme` to be eliminated, and lets us adopt all of the same schemes as those supported by the ClickHouse 26.7 `url()` function. Notably there are four options for Azure Block storage, but the one used previously, `abs`, is not among them.