### PR TITLE
Don't copy without a table for now

### DIFF
--- a/src/hook.c
+++ b/src/hook.c
@@ -149,7 +149,7 @@ chDBProcessUtilityHook(
         /* Look for a URL filename. */
         CopyStmt* copy = (CopyStmt*)parsetree;
         scheme scheme  = scheme_for(copy->filename);
-        if (scheme != no_scheme) {
+        if (copy->relation && scheme != no_scheme) {
             /* We own this copy. Fire up a worker to execute it. */
             char* schema = copy->relation->schemaname
                                ? copy->relation->schemaname

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -173,6 +173,9 @@ NOTICE:  CHUNK: 1	2	3
 3	2	1
 4	5	6
 
+-- No table support yet
+COPY (SELECT 1 AS x) TO 's3://bucket/key';
+ERROR:  relative path not allowed for COPY to file
 CREATE SCHEMA "big deal";
 CREATE TABLE "big deal"."myParts" (
     part_id   BIGINT PRIMARY KEY,

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -75,6 +75,10 @@ COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-tes
 COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv' (
     STRUCTURE 'id UInt32, num UInt32, age UInt32'
 );
+
+-- No table support yet
+COPY (SELECT 1 AS x) TO 's3://bucket/key';
+
 CREATE SCHEMA "big deal";
 
 CREATE TABLE "big deal"."myParts" (


### PR DESCRIPTION
Prevent a crash for a copy that matches our URL but uses a query rather than a table name. Just decline to handle that situation for now; can add in the future. Fixes #8.