### PR TITLE
Add file:// and hdfs:// support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,9 @@ jobs:
           md5sum /usr/local/lib/libchdb.so /usr/local/include/chdb.h
       - name: Test
         run: pg-build-test
+      - name: Upload Diffs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-diffs-pg${{ matrix.pg }}
+          path: regression.diffs

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -60,6 +60,9 @@ make_pg_query(chdbCopyContext* ctx, Relation rel, StringInfo query);
 static void
 parse_azure_url(char* url, azureURLParts* parts);
 
+static char*
+get_local_path_from_file_url(const char* url);
+
 static void
 chdb_conn_free(void*);
 
@@ -484,6 +487,44 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         );
         break;
     }
+    case file_scheme:
+        /* https://clickhouse.com/docs/sql-reference/table-functions/file#syntax */
+
+        /* First parameter: the path to the file. */
+        PARAM("{path:String}", "path", get_local_path_from_file_url(ctx->url));
+
+        /* Append remaining arguments and settings. */
+        if (ctx->compression[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+            PARAM(
+                ", {structure:String}",
+                "structure",
+                ctx->structure[0] ? ctx->structure : "auto"
+            );
+            PARAM(", {compression:String}", "compression", ctx->compression);
+        } else if (ctx->structure[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+            PARAM(", {structure:String}", "structure", ctx->structure);
+        } else if (ctx->format[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+        }
+        appendStringInfo(query, ") SETTINGS %s", settings);
+        break;
+    case hdfs_scheme:
+        /* https://clickhouse.com/docs/sql-reference/table-functions/hdfs#syntax */
+
+        /* First parameter: the base URL. */
+        PARAM("{url:String}", "url", ctx->url);
+
+        /* Append remaining arguments and settings. */
+        if (ctx->structure[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+            PARAM(", {structure:String}", "structure", ctx->structure);
+        } else if (ctx->format[0] != '\0') {
+            PARAM(", {format:String}", "format", ctx->format);
+        }
+        appendStringInfo(query, ") SETTINGS %s", settings);
+        break;
     default:
         elog(ERROR, "unsupported URL scheme %d", ctx->extra.scheme);
         break;
@@ -572,6 +613,31 @@ parse_azure_url(char* url, azureURLParts* parts) {
             errhint("az://<account>.blob.core.windows.net/<container>/<path>")
         );
     }
+}
+
+/*
+ * Get the local path from a file:// URL. Must be an absolute path or else it
+ * raises an error.
+ */
+static char*
+get_local_path_from_file_url(const char* url) {
+    /* https://github.com/ClickHouse/ClickHouse/blob/0b235b0/src/Storages/StorageURL.cpp#L2000-L2014*/
+    char* path = strstr(url, "://");
+    if (!path) {
+        /* Should not happen, validated by the hook. */
+        elog(ERROR, "chdb: malformed file URL %s ", url);
+    }
+
+    path += 3;
+    if (!is_absolute_path(path)) {
+        ereport(
+            ERROR,
+            errcode(ERRCODE_INVALID_NAME),
+            errmsg("chdb: relative path not allowed for COPY to file URL")
+        );
+    }
+
+    return path;
 }
 
 /*

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -41,8 +41,8 @@ typedef enum scheme {
     s3_scheme,
     gcs_scheme,
     abs_scheme,
-    // file_scheme,
-    // hdfs_scheme,
+    file_scheme,
+    hdfs_scheme,
     no_scheme, /* Must be last.*/
 } scheme;
 
@@ -55,8 +55,8 @@ static char const* const table_function[] = {
     [s3_scheme]   = "s3",
     [gcs_scheme]  = "gcs", /* Alias of s3, but keep it explicit.*/
     [abs_scheme]  = "azureBlobStorage",
-    // [file_scheme] = "file",
-    // [hdfs_scheme] = "hdfs",
+    [file_scheme] = "file",
+    [hdfs_scheme] = "hdfs",
 };
 
 /*
@@ -70,8 +70,8 @@ static char const* const scheme_name[no_scheme][5] = {
     [s3_scheme]   = { "s3" },
     [gcs_scheme]  = { "gs", "gcs", "oss" },
     [abs_scheme]  = { "az", "azure", "abfss", "abfs" },
-    // [file_scheme] = { "file", NULL },
-    // [hdfs_scheme] = { "hdfs", NULL },
+    [file_scheme] = { "file", NULL },
+    [hdfs_scheme] = { "hdfs", NULL },
 };
 
 /*

--- a/test/expected/copy_1.out
+++ b/test/expected/copy_1.out
@@ -116,7 +116,7 @@ NOTICE:  CH QUERY: SELECT * FROM hdfs({url:String}) SETTINGS date_time_output_fo
 PARAMS: url: "hdfs://localhost:9865/test"
 NOTICE:  PG QUERY: COPY logs FROM STDIN (FORMAT text);
 ERROR:  error fetching chDB query result
-DETAIL:  Code: 46. DB::Exception: Unknown table function hdfs. (UNKNOWN_FUNCTION)
+DETAIL:  Code: 660. DB::Exception: Unable to connect to HDFS: Hdfs::HdfsRpcException: HdfsFailoverException: Failed to invoke RPC call "getFsStats" on server "localhost:9865"	Caused by: HdfsNetworkConnectException: Connect to "localhost:9865" failed: (errno: 111) Connection refused: The data format cannot be detected by the contents of the files. You can specify the format manually. (HDFS_ERROR)
 CONTEXT:  query: SELECT * FROM hdfs({url:String}) SETTINGS date_time_output_format='iso'
 COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv' (
     access_key 'key',
@@ -199,7 +199,7 @@ NOTICE:  CH QUERY: SELECT * FROM hdfs({url:String}, {format:String}, {structure:
 PARAMS: url: "hdfs://localhost:9865/test", format: "CSV", structure: "id UInt32, num UInt32, age UInt32"
 NOTICE:  PG QUERY: COPY logs FROM STDIN (FORMAT text);
 ERROR:  error fetching chDB query result
-DETAIL:  Code: 46. DB::Exception: Unknown table function hdfs. (UNKNOWN_FUNCTION)
+DETAIL:  Code: 660. DB::Exception: Unable to connect to HDFS: Hdfs::HdfsRpcException: HdfsFailoverException: Failed to invoke RPC call "getFsStats" on server "localhost:9865"	Caused by: HdfsNetworkConnectException: Connect to "localhost:9865" failed: (errno: 111) Connection refused: While executing ReadFromObjectStorage. (HDFS_ERROR)
 CONTEXT:  query: SELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso'
 COPY logs FROM 'hdfs://localhost:9865/test' (
     STRUCTURE 'id UInt32, num UInt32, age UInt32'
@@ -208,7 +208,7 @@ NOTICE:  CH QUERY: SELECT * FROM hdfs({url:String}, {format:String}, {structure:
 PARAMS: url: "hdfs://localhost:9865/test", format: "auto", structure: "id UInt32, num UInt32, age UInt32"
 NOTICE:  PG QUERY: COPY logs FROM STDIN (FORMAT text);
 ERROR:  error fetching chDB query result
-DETAIL:  Code: 46. DB::Exception: Unknown table function hdfs. (UNKNOWN_FUNCTION)
+DETAIL:  Code: 660. DB::Exception: Unable to connect to HDFS: Hdfs::HdfsRpcException: HdfsFailoverException: Failed to invoke RPC call "getFsStats" on server "localhost:9865"	Caused by: HdfsNetworkConnectException: Connect to "localhost:9865" failed: (errno: 111) Connection refused: The data format cannot be detected by the contents of the files. You can specify the format manually. (HDFS_ERROR)
 CONTEXT:  query: SELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso'
 -- No table support yet
 COPY (SELECT 1 AS x) TO 's3://bucket/key';

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -28,12 +28,16 @@ COPY logs TO 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-b
 COPY logs TO 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs TO 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
 COPY logs TO 'az://account.blob.core.windows.net/container/path/to.csv';
+COPY logs TO 'file://logs.csv';
+COPY logs TO 'hdfs://localhost:9865/test';
 
 COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs FROM 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 COPY logs FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
 COPY logs FROM 'az://account.blob.core.windows.net/container/path/to.csv';
+COPY logs FROM 'file://logs.csv';
+COPY logs FROM 'hdfs://localhost:9865/test';
 
 COPY logs FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv' (
     access_key 'key',
@@ -73,6 +77,15 @@ COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-tes
 );
 
 COPY logs FROM 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv' (
+    STRUCTURE 'id UInt32, num UInt32, age UInt32'
+);
+
+COPY logs FROM 'hdfs://localhost:9865/test' (
+    FORMAT 'CSV',
+    STRUCTURE 'id UInt32, num UInt32, age UInt32'
+);
+
+COPY logs FROM 'hdfs://localhost:9865/test' (
     STRUCTURE 'id UInt32, num UInt32, age UInt32'
 );
 


### PR DESCRIPTION
Brings the feature into line with the `url()` table function due in Clickhouse 26.7. The file support in particular will allow efficient, deep testing of features without the network overhead.

For now the file tests fail with a relative path, because we can't use an absolute path in the current tests. Once the COPY features have been implemented, we'll add proper tests for the behaviors rather than the current debugging-style output.

The `hdfs()` function is a little unreliable at the moment, returning `Unknown table function hdfs` on macOS but not Linux. Just include two expect files for now.