### PR TITLE
Report number of rows copied

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -12,6 +12,7 @@
 #include "access/xact.h"
 #include "catalog/namespace.h"
 #include "libpq/libpq.h"
+#include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
 #include "storage/ipc.h"
 #include "storage/shm_toc.h"
@@ -219,6 +220,7 @@ chdb_bgw_main(Datum main_arg) {
     );
 
     const char* error;
+    uint64_t num_rows = 0;
 
     /* [Complete List of
      * Formats](https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table)
@@ -271,7 +273,7 @@ chdb_bgw_main(Datum main_arg) {
             );
 
             /* Do the copy. */
-            (void)CopyFrom(cstate);
+            num_rows = CopyFrom(cstate);
             EndCopyFrom(cstate);
         }
         PG_CATCH();
@@ -318,7 +320,7 @@ chdb_bgw_main(Datum main_arg) {
                 NIL
             );
 
-            (void)DoCopyTo(cstate);
+            num_rows = DoCopyTo(cstate);
             EndCopyTo(cstate);
 
             /* Tell chDB the insert is done. */
@@ -356,10 +358,18 @@ chdb_bgw_main(Datum main_arg) {
         StreamingInProgress = false;
     }
 
-    /* Report success and exit. */
+    /* Success! Close and commit. */
     table_close(rel, ctx->extra.is_from ? RowExclusiveLock : AccessShareLock);
     PopActiveSnapshot();
     CommitTransactionCommand();
+
+    /* Progress report. See pgstat_progress_parallel_incr_param for format. */
+    StringInfo msg = makeStringInfoExt(sizeof(uint32_t) + sizeof(uint64_t));
+    pq_sendint32(msg, 0); /* unused for now */
+    pq_sendint64(msg, num_rows);
+    pq_putmessage(PqMsg_Progress, msg->data, msg->len);
+
+    /* Report success and exit. */
     pq_putmessage(PqMsg_Terminate, NULL, 0);
     proc_exit(0);
 }

--- a/src/hook.c
+++ b/src/hook.c
@@ -40,13 +40,13 @@ chDBProcessUtilityHook(
 void
 InitializeUtilityHook(void);
 void
-LaunchWorker(chdbCopyContext* ctx);
+LaunchWorker(chdbCopyContext* ctx, QueryCompletion* qc);
 scheme
 scheme_for(const char* str);
 static void
 contextualize_options(chdbCopyContext* ctx, List* options);
 void
-ProcessMessages(shm_mq_handle* queue);
+ProcessMessages(shm_mq_handle* queue, QueryCompletion* qc);
 
 /*
  * InitializeUtilityHook hooks chDBProcessUtilityHook into the process utility
@@ -137,7 +137,7 @@ chDBProcessUtilityHook(
     ParamListInfo params,
     struct QueryEnvironment* queryEnv,
     DestReceiver* dest,
-    QueryCompletion* completionTag
+    QueryCompletion* qc
 ) {
     Node* parsetree = plannedStmt->utilityStmt;
 
@@ -162,7 +162,7 @@ chDBProcessUtilityHook(
                 .url     = copy->filename,
             };
             contextualize_options(&ctx, copy->options);
-            LaunchWorker(&ctx);
+            LaunchWorker(&ctx, qc);
 
             return;
         }
@@ -170,14 +170,7 @@ chDBProcessUtilityHook(
 
     /* Continue with the internal execution. */
     PrevProcessUtility(
-        plannedStmt,
-        queryString,
-        readOnlyTree,
-        context,
-        params,
-        queryEnv,
-        dest,
-        completionTag
+        plannedStmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc
     );
 }
 
@@ -185,7 +178,7 @@ chDBProcessUtilityHook(
  * Dynamically launch a chDB worker.
  */
 void
-LaunchWorker(chdbCopyContext* ctx) {
+LaunchWorker(chdbCopyContext* ctx, QueryCompletion* qc) {
     /* Size the shared memory for the chdbCopyContext. */
     shm_toc_estimator estimator;
 
@@ -311,7 +304,7 @@ LaunchWorker(chdbCopyContext* ctx) {
 
     /* Wait for it to finish. */
     PG_TRY();
-    { ProcessMessages(mqh); }
+    { ProcessMessages(mqh, qc); }
     PG_FINALLY();
     { dsm_detach(seg); }
     PG_END_TRY();
@@ -325,10 +318,11 @@ LaunchWorker(chdbCopyContext* ctx) {
  * queue has been drained.
  */
 void
-ProcessMessages(shm_mq_handle* queue) {
+ProcessMessages(shm_mq_handle* queue, QueryCompletion* qc) {
     Size msg_len;
     void* data;
     StringInfoData msg;
+    initStringInfo(&msg);
 
     for (;;) {
         CHECK_FOR_INTERRUPTS();
@@ -342,7 +336,6 @@ ProcessMessages(shm_mq_handle* queue) {
             );
         }
 
-        initStringInfo(&msg);
         appendBinaryStringInfo(&msg, data, msg_len);
         int msg_type = pq_getmsgbyte(&msg);
 
@@ -356,9 +349,17 @@ ProcessMessages(shm_mq_handle* queue) {
             /* Death of a worker isn't enough justification for suicide. */
             err.elevel = Min(err.elevel, ERROR);
 
-            /* Clean up and rethrow error or print notice. */
-            pfree(msg.data);
+            /* Rethrow error or print notice, then reset. */
             ThrowErrorData(&err);
+            resetStringInfo(&msg);
+            break;
+        }
+        case PqMsg_Progress: {
+            /* Progress report. See pgstat_progress_parallel_incr_param for format. */
+            (void)pq_getmsgint(&msg, sizeof(uint32_t)); /* unused for now */
+            qc->nprocessed = pq_getmsgint64(&msg);
+            qc->commandTag = CMDTAG_COPY;
+            resetStringInfo(&msg);
             break;
         }
         case PqMsg_Terminate:
@@ -367,7 +368,7 @@ ProcessMessages(shm_mq_handle* queue) {
             return;
 
         default:
-            pfree(msg.data);
+            resetStringInfo(&msg);
             elog(
                 WARNING, "unexpected message type: %c (%zu bytes)", msg.data[0], msg_len
             );

--- a/test/expected/file.out
+++ b/test/expected/file.out
@@ -4,11 +4,14 @@ CREATE TABLE requests (
     name      TEXT     NOT NULL,
     path      TEXT     NOT NULL
 );
+-- Disable quiet to emit COPY numbers.
+\set QUIET false
 -- directory paths are passed to us in environment variables
 \getenv test_dir PG_ABS_SRCDIR
 \set file_base file:// :test_dir /corpus
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
+COPY 4
 SELECT * FROM requests ORDER BY req_id;
  req_id |    name     |       path       
 --------+-------------+------------------
@@ -21,6 +24,7 @@ SELECT * FROM requests ORDER BY req_id;
 \set temp_base file:// :test_dir /temp
 \set dest :temp_base /requests.csv
 COPY requests TO :'dest' (structure 'id UInt64, name String, path String');
+COPY 4
 \! cat test/temp/requests.csv
 1,"page_view","/users/profile"
 2,"Page_View","/users/settings"

--- a/test/sql/file.sql
+++ b/test/sql/file.sql
@@ -6,6 +6,9 @@ CREATE TABLE requests (
     path      TEXT     NOT NULL
 );
 
+-- Disable quiet to emit COPY numbers.
+\set QUIET false
+
 -- directory paths are passed to us in environment variables
 \getenv test_dir PG_ABS_SRCDIR
 \set file_base file:// :test_dir /corpus


### PR DESCRIPTION
Use a `PqMsg_Progress` to report them, with the same format as used by the parallel background workers. We don't currently do anything with the index, but could in the future. It seemed the best option.

Use this message to populate the `QueryCompletion` with the result, so that it gets reported to the client. Turn off quiet mode in the file test to prove it.

While at it, reset the StringInfo after retrieving each message, and only free it when done. We don't free it on error, but the memory context will clean it up soon enough.