### PR TITLE
Test tab escape compatibility

### DIFF
--- a/test/corpus/people.tsv
+++ b/test/corpus/people.tsv
@@ -1,0 +1,7 @@
+1	Obama	Barack	\'Bama to his friends
+2	Clinton	William	Hillary\tChelsea\tSocks\n
+3	Gates	Bill	Dos\r\nWindows\r\nExplorer
+4	Matrix	Dot	a \f b \f c \f \b
+5	Language	C	\N
+6 	Others 	Some	go \\ get \a your \v mouse \x40
+7	Others	Some	go \\ get  your  mouse @

--- a/test/expected/file.out
+++ b/test/expected/file.out
@@ -4,11 +4,13 @@ CREATE TABLE requests (
     name      TEXT     NOT NULL,
     path      TEXT     NOT NULL
 );
--- Disable quiet to emit COPY numbers.
+-- Disable quiet to emit COPY numbers and make NULLs show up
+\pset null '#null#'
 \set QUIET false
 -- directory paths are passed to us in environment variables
 \getenv test_dir PG_ABS_SRCDIR
 \set file_base file:// :test_dir /corpus
+\set temp_base file:// :test_dir /temp
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
 COPY 4
@@ -21,13 +23,71 @@ SELECT * FROM requests ORDER BY req_id;
       4 | add_to_cart | /products/shoes
 (4 rows)
 
-\set temp_base file:// :test_dir /temp
-\set dest :temp_base /requests.csv
-COPY requests TO :'dest' (structure 'id UInt64, name String, path String');
+\set requests_out :temp_base /requests.csv
+COPY requests TO :'requests_out' (structure 'id UInt64, name String, path String');
 COPY 4
 \! cat test/temp/requests.csv
 1,"page_view","/users/profile"
 2,"Page_View","/users/settings"
 3,"PAGE_VIEW","/admin/dashboard"
 4,"add_to_cart","/products/shoes"
+-- Test importing from ClickHouse with all possible backslash escapes.
+-- https://clickhouse.com/docs/interfaces/formats/TabSeparated
+CREATE TABLE people (
+    id           INT PRIMARY KEY,
+    family_name  TEXT NOT NULL,
+    given_name   TEXT NOT NULL,
+    notes        TEXT     NULL
+);
+CREATE TABLE
+\set people_tsv :file_base /people.tsv
+COPY people FROM :'people_tsv';
+COPY 7
+SELECT * FROM people ORDER BY id;
+ id | family_name | given_name |              notes              
+----+-------------+------------+---------------------------------
+  1 | Obama       | Barack     | 'Bama to his friends
+  2 | Clinton     | William    | Hillary Chelsea Socks          +
+    |             |            | 
+  3 | Gates       | Bill       | Dos\r                          +
+    |             |            | Windows\r                      +
+    |             |            | Explorer
+  4 | Matrix      | Dot        | a \x0C b \x0C c \x0C \x08
+  5 | Language    | C          | #null#
+  6 | Others      | Some       | go \ get \x07 your \x0B mouse @
+  7 | Others      | Some       | go \ get \x07 your \x0B mouse @
+(7 rows)
+
+-- Export back out.
+\set people_out :temp_base /people.tsv
+COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
+COPY 7
+\! cat test/temp/people.tsv
+1	Obama	Barack	\'Bama to his friends
+2	Clinton	William	Hillary\tChelsea\tSocks\n
+3	Gates	Bill	Dos\r\nWindows\r\nExplorer
+4	Matrix	Dot	a \f b \f c \f \b
+5	Language	C	\N
+6	Others 	Some	go \\ get  your  mouse @
+7	Others	Some	go \\ get  your  mouse @
+-- Import it again;
+TRUNCATE people;
+TRUNCATE TABLE
+COPY people FROM :'people_out';
+COPY 7
+SELECT * FROM people ORDER BY id;
+ id | family_name | given_name |              notes              
+----+-------------+------------+---------------------------------
+  1 | Obama       | Barack     | 'Bama to his friends
+  2 | Clinton     | William    | Hillary Chelsea Socks          +
+    |             |            | 
+  3 | Gates       | Bill       | Dos\r                          +
+    |             |            | Windows\r                      +
+    |             |            | Explorer
+  4 | Matrix      | Dot        | a \x0C b \x0C c \x0C \x08
+  5 | Language    | C          | #null#
+  6 | Others      | Some       | go \ get \x07 your \x0B mouse @
+  7 | Others      | Some       | go \ get \x07 your \x0B mouse @
+(7 rows)
+
 \! rm -rf test/temp

--- a/test/sql/file.sql
+++ b/test/sql/file.sql
@@ -6,20 +6,44 @@ CREATE TABLE requests (
     path      TEXT     NOT NULL
 );
 
--- Disable quiet to emit COPY numbers.
+-- Disable quiet to emit COPY numbers and make NULLs show up
+\pset null '#null#'
 \set QUIET false
 
 -- directory paths are passed to us in environment variables
 \getenv test_dir PG_ABS_SRCDIR
 \set file_base file:// :test_dir /corpus
+\set temp_base file:// :test_dir /temp
 
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
 SELECT * FROM requests ORDER BY req_id;
 
-\set temp_base file:// :test_dir /temp
-\set dest :temp_base /requests.csv
-COPY requests TO :'dest' (structure 'id UInt64, name String, path String');
-
+\set requests_out :temp_base /requests.csv
+COPY requests TO :'requests_out' (structure 'id UInt64, name String, path String');
 \! cat test/temp/requests.csv
+
+-- Test importing from ClickHouse with all possible backslash escapes.
+-- https://clickhouse.com/docs/interfaces/formats/TabSeparated
+CREATE TABLE people (
+    id           INT PRIMARY KEY,
+    family_name  TEXT NOT NULL,
+    given_name   TEXT NOT NULL,
+    notes        TEXT     NULL
+);
+
+\set people_tsv :file_base /people.tsv
+COPY people FROM :'people_tsv';
+SELECT * FROM people ORDER BY id;
+
+-- Export back out.
+\set people_out :temp_base /people.tsv
+COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
+\! cat test/temp/people.tsv
+
+-- Import it again;
+TRUNCATE people;
+COPY people FROM :'people_out';
+SELECT * FROM people ORDER BY id;
+
 \! rm -rf test/temp


### PR DESCRIPTION
Add tests to `test/sql/file.sql` that load a table from a TSV file that contains all of the backslash escapes generated by ClickHouse to verify that Postgres properly processes them. It does. Also have it write out the same data and compare the results. The data is identical.