### PR TITLE
Add test exporting and importing 100MB in Parquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ compile_commands.json
 log/
 /test/schedule
 /tmp_check/
+*.tmp

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DISTVERSION  = $(shell grep -m 1 '^[[:space:]]\{2\}"version":' META.json | \
 DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql)
 DOCS         = $(wildcard doc/*.md)
 TESTS        ?= $(wildcard test/sql/*.sql)
-REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
+REGRESS      = --schedule test/schedule
 REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 MODULE_big   = $(EXTENSION)
 PG_CONFIG   ?= pg_config
@@ -21,7 +21,7 @@ OBJS = $(subst .c,.o, $(wildcard src/*.c))
 PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
 
 # Clean up generated files.
-EXTRA_CLEAN  = src/version.h sql/$(EXTENSION)--$(EXTVERSION).sql src/bgw/chdb_bgw.* src/bgw/worker.o src/bgw/worker.bc
+EXTRA_CLEAN  = src/version.h sql/$(EXTENSION)--$(EXTVERSION).sql src/bgw/chdb_bgw.* src/bgw/worker.o src/bgw/worker.bc test/schedule
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
@@ -56,6 +56,12 @@ uninstall-bgw:
 	rm -f $(DESTDIR)$(pkglibdir)/src/bgw/chdb_bgw$(DLSUFFIX)
 install: install-bgw
 uninstall: uninstall-bgw
+
+.PHONY: test/schedule # Depends on $(TESTS), so always rebuild.
+test/schedule:
+	@echo "test: $(patsubst test/sql/%.sql,%,$(TESTS))" > $@
+
+installcheck: test/schedule
 
 .PHONY: format # Format .c and .h files to project standard in .clang-format.
 format: $(wildcard src/*.c src/*.h src/bgw/*.c src/bgw/*.h)

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -229,6 +229,7 @@ chdb_bgw_main(Datum main_arg) {
      * Formats](https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table)
      */
     if (ctx->extra.is_from) {
+        // elog(NOTICE, "QUERY: %s", ch_query.data);
         /* Start streaming the chDB query. */
         chDBStreamingResult = chdb_stream_query_with_params(
             *chDBConnection,
@@ -803,6 +804,7 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
             CopyBuf->data   = chdb_result_buffer(chunk);
             CopyBuf->len    = (int)chunk_length;
             CopyBuf->cursor = 0;
+            // elog(NOTICE, "%s", pnstrdup(CopyBuf->data, CopyBuf->len));
 
             avail = CopyBuf->len - CopyBuf->cursor;
             if (avail > maxread) {
@@ -827,6 +829,7 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
 static void
 send_chdb_data(void* data, int len) {
     CHECK_FOR_INTERRUPTS();
+    // elog(NOTICE, "%s", pnstrdup(data, len));
     if (chdb_stream_append(chDBInsertStream, data, len) != CHDBSuccess ||
         chdb_stream_append(chDBInsertStream, "\n", 1) != CHDBSuccess) {
         const char* error = pstrdup(chdb_stream_insert_error(chDBInsertStream));

--- a/test/expected/big-parquet.out
+++ b/test/expected/big-parquet.out
@@ -1,0 +1,58 @@
+LOAD 'chdb';
+SET datestyle = 'ISO';
+SET session timezone = 'UTC'; -- https://github.com/chdb-io/chdb-core/issues/143
+\getenv test_dir PG_ABS_SRCDIR
+\set parquet_file file:// :test_dir /big.tmp/big.parquet
+CREATE TYPE http_method AS ENUM(
+  'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT',
+   'OPTIONS', 'TRACE', 'PATCH', 'QUERY'
+);
+\set ECHO errors
+CREATE TABLE  logs (
+    req_id    BIGINT,
+    start_at  TIMESTAMP,
+    duration  INTEGER,
+    resource  TEXT,
+    method    http_method,
+    node_id   BIGINT,
+    response  INTEGER
+);
+-- Fill the table with ca 100MB of records.
+INSERT INTO logs
+SELECT random(0, +9223372036854775807),
+       concat('2025-12-19 10:42:00.', floor(random(0, 999999)))::timestamp - (random(1, 86400 * 14) || 's')::interval,
+       random(1, 500) AS duration,
+       (ARRAY['/profile', '/users', '/users/1321945', '/users/283434', '/users/802683', '/users/1739238', '/users/7392323', '/widgets', '/search', '/search', '/search', '/widgets/omnis', '/widgets/natus', '/widgets/voluptatem', '/widgets/totam', '/widgets/aperiam'])[random(1, 15)],
+       (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 91 THEN 'GET' WHEN a < 97 THEN 'POST' WHEN a < 99 THEN 'PUT' ELSE (ARRAY['HEAD', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH', 'QUERY'])[random(x-x+1, 7)] END FROM x)::http_method,
+       random(1, 8) AS node_id,
+       (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 95 THEN 200 WHEN a < 97 THEN 201 WHEN a < 99 THEN 204 ELSE (ARRAY[308, 400, 401, 403, 500])[random(x-x+1, 5)] END FROM x)
+-- FROM generate_series(1, 10) x;
+FROM generate_series(1, 1260000) x;
+SELECT pg_size_pretty(pg_total_relation_size('logs'));
+ pg_size_pretty 
+----------------
+ 100 MB
+(1 row)
+
+-- Copy out the data
+COPY logs TO :'parquet_file' (structure $$
+    req_id    UInt64,
+    start_at  DateTime64(6, 'UTC'),
+    duration  UInt16,
+    resource  String,
+    method    String,
+    node_id   UInt32,
+    response  UInt16
+$$);
+-- Load it back in.
+CREATE TABLE imported_logs (LIKE logs INCLUDING ALL);
+COPY imported_logs FROM :'parquet_file';
+-- They should be the same
+SELECT * FROM logs
+EXCEPT ALL
+SELECT * FROM imported_logs;
+ req_id | start_at | duration | resource | method | node_id | response 
+--------+----------+----------+----------+--------+---------+----------
+(0 rows)
+
+\! rm -rf test/big.tmp

--- a/test/expected/file.out
+++ b/test/expected/file.out
@@ -10,7 +10,7 @@ CREATE TABLE requests (
 -- directory paths are passed to us in environment variables
 \getenv test_dir PG_ABS_SRCDIR
 \set file_base file:// :test_dir /corpus
-\set temp_base file:// :test_dir /temp
+\set temp_base file:// :test_dir /file.tmp
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
 COPY 4
@@ -26,7 +26,7 @@ SELECT * FROM requests ORDER BY req_id;
 \set requests_out :temp_base /requests.csv
 COPY requests TO :'requests_out' (structure 'id UInt64, name String, path String');
 COPY 4
-\! cat test/temp/requests.csv
+\! cat test/file.tmp/requests.csv
 1,"page_view","/users/profile"
 2,"Page_View","/users/settings"
 3,"PAGE_VIEW","/admin/dashboard"
@@ -62,7 +62,7 @@ SELECT * FROM people ORDER BY id;
 \set people_out :temp_base /people.tsv
 COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
 COPY 7
-\! cat test/temp/people.tsv
+\! cat test/file.tmp/people.tsv
 1	Obama	Barack	\'Bama to his friends
 2	Clinton	William	Hillary\tChelsea\tSocks\n
 3	Gates	Bill	Dos\r\nWindows\r\nExplorer
@@ -90,4 +90,4 @@ SELECT * FROM people ORDER BY id;
   7 | Others      | Some       | go \ get \x07 your \x0B mouse @
 (7 rows)
 
-\! rm -rf test/temp
+\! rm -rf test/file.tmp

--- a/test/sql/big-parquet.sql
+++ b/test/sql/big-parquet.sql
@@ -1,0 +1,66 @@
+LOAD 'chdb';
+SET datestyle = 'ISO';
+SET session timezone = 'UTC'; -- https://github.com/chdb-io/chdb-core/issues/143
+
+\getenv test_dir PG_ABS_SRCDIR
+\set parquet_file file:// :test_dir /big.tmp/big.parquet
+
+CREATE TYPE http_method AS ENUM(
+  'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT',
+   'OPTIONS', 'TRACE', 'PATCH', 'QUERY'
+);
+
+\set ECHO errors
+SELECT current_setting('server_version_num')::int < 170000 AS pg16 \gset
+\if :pg16
+CREATE OR REPLACE FUNCTION random(min bigint, max bigint) RETURNS bigint LANGUAGE SQL volatile AS $$
+    SELECT random() * (max-min) + min;
+$$;
+\endif
+\set ECHO all
+
+CREATE TABLE  logs (
+    req_id    BIGINT,
+    start_at  TIMESTAMP,
+    duration  INTEGER,
+    resource  TEXT,
+    method    http_method,
+    node_id   BIGINT,
+    response  INTEGER
+);
+
+-- Fill the table with ca 100MB of records.
+INSERT INTO logs
+SELECT random(0, +9223372036854775807),
+       concat('2025-12-19 10:42:00.', floor(random(0, 999999)))::timestamp - (random(1, 86400 * 14) || 's')::interval,
+       random(1, 500) AS duration,
+       (ARRAY['/profile', '/users', '/users/1321945', '/users/283434', '/users/802683', '/users/1739238', '/users/7392323', '/widgets', '/search', '/search', '/search', '/widgets/omnis', '/widgets/natus', '/widgets/voluptatem', '/widgets/totam', '/widgets/aperiam'])[random(1, 15)],
+       (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 91 THEN 'GET' WHEN a < 97 THEN 'POST' WHEN a < 99 THEN 'PUT' ELSE (ARRAY['HEAD', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH', 'QUERY'])[random(x-x+1, 7)] END FROM x)::http_method,
+       random(1, 8) AS node_id,
+       (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 95 THEN 200 WHEN a < 97 THEN 201 WHEN a < 99 THEN 204 ELSE (ARRAY[308, 400, 401, 403, 500])[random(x-x+1, 5)] END FROM x)
+-- FROM generate_series(1, 10) x;
+FROM generate_series(1, 1260000) x;
+
+SELECT pg_size_pretty(pg_total_relation_size('logs'));
+
+-- Copy out the data
+COPY logs TO :'parquet_file' (structure $$
+    req_id    UInt64,
+    start_at  DateTime64(6, 'UTC'),
+    duration  UInt16,
+    resource  String,
+    method    String,
+    node_id   UInt32,
+    response  UInt16
+$$);
+
+-- Load it back in.
+CREATE TABLE imported_logs (LIKE logs INCLUDING ALL);
+COPY imported_logs FROM :'parquet_file';
+
+-- They should be the same
+SELECT * FROM logs
+EXCEPT ALL
+SELECT * FROM imported_logs;
+
+\! rm -rf test/big.tmp

--- a/test/sql/file.sql
+++ b/test/sql/file.sql
@@ -13,7 +13,7 @@ CREATE TABLE requests (
 -- directory paths are passed to us in environment variables
 \getenv test_dir PG_ABS_SRCDIR
 \set file_base file:// :test_dir /corpus
-\set temp_base file:// :test_dir /temp
+\set temp_base file:// :test_dir /file.tmp
 
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
@@ -21,7 +21,7 @@ SELECT * FROM requests ORDER BY req_id;
 
 \set requests_out :temp_base /requests.csv
 COPY requests TO :'requests_out' (structure 'id UInt64, name String, path String');
-\! cat test/temp/requests.csv
+\! cat test/file.tmp/requests.csv
 
 -- Test importing from ClickHouse with all possible backslash escapes.
 -- https://clickhouse.com/docs/interfaces/formats/TabSeparated
@@ -39,11 +39,11 @@ SELECT * FROM people ORDER BY id;
 -- Export back out.
 \set people_out :temp_base /people.tsv
 COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
-\! cat test/temp/people.tsv
+\! cat test/file.tmp/people.tsv
 
 -- Import it again;
 TRUNCATE people;
 COPY people FROM :'people_out';
 SELECT * FROM people ORDER BY id;
 
-\! rm -rf test/temp
+\! rm -rf test/file.tmp


### PR DESCRIPTION
Add `test/sql/big-parquet.sql`, which creates a 100MB table, `COPY`s it to a Parquet file, imports from that file into a new table, then confirms that the records in both are identical. Runs in ca. 14s on my Mac.

*   Update the `Makefile` to run the tests in parallel by adding a schedule file
*   Add and comment out some `elog()` calls in `worker.c` as I keep forgetting the syntax whenever I'm doing debugging
*   Change the name of the temp directory used by `test/sql/file.sql` to `file.tmp`, use `big.tmp` in `test/sql/big-parquet.sql`, and add `*.tmp` to `.gitignore`

Issues confirmed while adding this test:

*   `INTERVAL` is not a recognized ClickHouse type
*   The `Z` is missing from DateTime values returned by chDB with `SETTINGS date_time_output_format='iso'` (chdb-io/chdb-core#143)
*   GUCs set in the session do not propagate to the worker