### PR TITLE
engine_file_truncate_on_insert

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -399,7 +399,8 @@ static bool isInsert = false;
     i++;
 
 /* Default chDB query settings. */
-static const char settings[] = "date_time_output_format='iso'";
+static const char settings[] = "date_time_output_format='iso', "
+                               "engine_file_truncate_on_insert=1";
 
 size_t
 make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values) {

--- a/t/table-functions.pl
+++ b/t/table-functions.pl
@@ -67,13 +67,13 @@ subtest s3 => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 's3://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QSELECT * FROM s3({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000],
+        qr[\QSELECT * FROM s3({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 's3://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QINSERT INTO FUNCTION s3('s3://localhost\E:$port\Q/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000],
+        qr[\QINSERT INTO FUNCTION s3('s3://localhost\E:$port\Q/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv" }],
     );
     check_query(
@@ -89,7 +89,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", session_token: "big fat token", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
     check_query(
@@ -104,7 +104,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "", session_token: "some token", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
     check_query(
@@ -118,7 +118,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
     check_query(
@@ -130,7 +130,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "id Int64" }],
     );
     check_query(
@@ -142,7 +142,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "auto", compression: "snappy" }],
     );
     check_query(
@@ -153,7 +153,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "auto", compression: "snappy" }],
     );
     check_query(
@@ -164,7 +164,7 @@ subtest s3 => sub {
                 timeout 100
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {format:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 100],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 100],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "tsv" }],
     );
 };
@@ -174,13 +174,13 @@ subtest gcs => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'gcs://example.org/bucket/prefix/file.csv'},
-        qr[\QSELECT * FROM gcs({url:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000],
+        qr[\QSELECT * FROM gcs({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'gcs://example.org/bucket/prefix/file.csv'},
-        qr[\QINSERT INTO FUNCTION gcs('https://example.org/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 30000],
+        qr[\QINSERT INTO FUNCTION gcs('https://example.org/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv" }],
     );
     check_query(
@@ -196,7 +196,7 @@ subtest gcs => sub {
                 timeout 0
             )
         },
-        qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
 };
@@ -207,31 +207,31 @@ subtest http => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'http://example.org/path/file.csv'},
-        qr[\QSELECT * FROM url({url:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'http://example.org/path/file.csv'},
-        qr[\QINSERT INTO FUNCTION url('http://example.org/path/file.csv') SETTINGS date_time_output_format='iso', http_connection_timeout=30, http_max_tries=1],
+        qr[\QINSERT INTO FUNCTION url('http://example.org/path/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv" }],
     );
     check_query(
         $node, 'TO format, structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (FORMAT 'TabSeparated', structure 'id Int32', timeout 500)},
-        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=1, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "TabSeparated", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (structure 'id Int32', timeout 1500)},
-        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=2, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=2, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO format',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (format 'x UInt16', timeout 100)},
-        qr[\QSELECT * FROM url({url:String}, {format:String}) SETTINGS date_time_output_format='iso', http_connection_timeout=1, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "x UInt16" }],
     );
 };
@@ -266,19 +266,19 @@ subtest azure => sub {
     check_query(
         $node, 'just FROM azure',
         q{COPY stuff FROM 'az://example.org/path/file.csv'},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "path", path: "file.csv", account_name: "", account_key: "" }],
     );
     check_query(
         $node, 'To azure with query',
         q{COPY stuff TO 'az://example.org/path/file.csv?x=y&abc=12'},
-        qr[\QINSERT INTO FUNCTION azureBlobStorage('https://example.org?x=y&abc=12', 'path', 'file.csv', '', '') SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000],
+        qr[\QINSERT INTO FUNCTION azureBlobStorage('https://example.org?x=y&abc=12', 'path', 'file.csv', '', '') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org?x=y&abc=12", container: "path", path: "file.csv", account_name: "", account_key: "" }],
     );
     check_query(
         $node, 'FROM azure with no path',
         q{COPY stuff FROM 'az://example.org/container'},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "container", path: "", account_name: "", account_key: "" }],
     );
     check_query(
@@ -294,28 +294,28 @@ subtest azure => sub {
                 timeout 200
             )
         },
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=200],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=200],
         qr[\Q{ url: "https://acc.example.org", container: "xyz", path: "yep.csv", account_name: "ac_name", account_key: "ac_key", format: "tsv", compression: "lz4", structure: "id Int32" }],
     );
 
     check_query(
         $node, 'FROM abfs with compression & structure',
         q{COPY stuff FROM 'abfs://container@account/xyz/yep.csv' (access_key 'ac-key', compression 'snappy', structure 'x String')},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://account.blob.core.windows.net", container: "container", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "snappy", structure: "x String" }],
     );
 
     check_query(
         $node, 'FROM abfss host with structure',
         q{COPY stuff FROM 'abfss://hi@example.org/xyz/yep.csv' (access_key 'ac-key', structure 'x String')},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "hi", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "", structure: "x String" }],
     );
 
     check_query(
         $node, 'FROM no-path abfs with format only',
         q{COPY stuff FROM 'abfs://slick@example.org' (format 'z Int8')},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}) SETTINGS date_time_output_format='iso', azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "slick", path: "", account_name: "", account_key: "", format: "z Int8" }],
     );
 };
@@ -331,21 +331,21 @@ subtest file => sub {
     check_query(
         $node, 'just FROM file',
         qq{COPY stuff FROM 'file://$dir/nonesuch.csv'},
-        qr[\QSELECT * FROM file({path:String}) SETTINGS date_time_output_format='iso'],
+        qr[\QSELECT * FROM file({path:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv" }],
     );
 
     check_query(
         $node, 'just TO file',
         qq{COPY stuff TO 'file://$dir/nonesuch.csv'},
-        qr[\QINSERT INTO FUNCTION file('$dir/nonesuch.csv') SETTINGS date_time_output_format='iso'],
+        qr[\QINSERT INTO FUNCTION file('$dir/nonesuch.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv" }],
     );
 
     check_query(
         $node, 'all options',
         qq{COPY stuff FROM 'file://$dir/nonesuch.csv' (compression 'lz4', structure 'z Int8', format 'tsv')},
-        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso'],
+        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv", format: "tsv", structure: "z Int8", compression: "lz4" }],
     );
 };
@@ -354,31 +354,31 @@ subtest hdfs => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QSELECT * FROM hdfs({url:String}) SETTINGS date_time_output_format='iso'],
+        qr[\QSELECT * FROM hdfs({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'hdfs://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QINSERT INTO FUNCTION hdfs('hdfs://localhost:\E$port\Q/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso'],
+        qr[\QINSERT INTO FUNCTION hdfs('hdfs://localhost:\E$port\Q/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv" }],
     );
     check_query(
         $node, 'FROM url with format and structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (FORMAT 'TSV', STRUCTURE 'a Int8')},
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso'],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TSV", structure: "a Int8" }],
     );
     check_query(
         $node, 'FROM url with structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (STRUCTURE 'a UInt8')},
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso'],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "a UInt8" }],
     );
     check_query(
         $node, 'FROM url with format',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (format 'TabSeparated')},
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}) SETTINGS date_time_output_format='iso'],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TabSeparated" }],
     );
 };

--- a/test/expected/file.out
+++ b/test/expected/file.out
@@ -90,4 +90,15 @@ SELECT * FROM people ORDER BY id;
   7 | Others      | Some       | go \ get \x07 your \x0B mouse @
 (7 rows)
 
+-- Export it again, should replace previous.
+COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
+COPY 7
+\! cat test/file.tmp/people.tsv
+1	Obama	Barack	\'Bama to his friends
+2	Clinton	William	Hillary\tChelsea\tSocks\n
+3	Gates	Bill	Dos\r\nWindows\r\nExplorer
+4	Matrix	Dot	a \f b \f c \f \b
+5	Language	C	\N
+6	Others 	Some	go \\ get  your  mouse @
+7	Others	Some	go \\ get  your  mouse @
 \! rm -rf test/file.tmp

--- a/test/sql/file.sql
+++ b/test/sql/file.sql
@@ -46,4 +46,8 @@ TRUNCATE people;
 COPY people FROM :'people_out';
 SELECT * FROM people ORDER BY id;
 
+-- Export it again, should replace previous.
+COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
+\! cat test/file.tmp/people.tsv
+
 \! rm -rf test/file.tmp


### PR DESCRIPTION
Pass `engine_file_truncate_on_insert=1` to all queries to bring the chDB table function behavior in line with the Postgres `COPY` behavior, which always writes a new file.