### PR TITLE
Build structure argument from Postgres table

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -10,9 +10,11 @@
 #include "storage/latch.h"
 
 /* these headers are used by this particular worker's code */
+#include "access/htup_details.h"
 #include "access/table.h"
 #include "access/xact.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_type.h"
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
@@ -25,6 +27,7 @@
 #include "utils/memutils.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
+#include "utils/syscache.h"
 #if PG_VERSION_NUM >= 190000
 #include "storage/proc.h"
 #endif
@@ -56,6 +59,18 @@ static StringInfo CopyBuf = NULL;
 
 /* Indicates whether streaming is in progress. */
 static bool StreamingInProgress = false;
+
+/* Returns the ClickHouse type name that corresponds to the `attr` type. */
+static const char*
+chdb_type_for(Form_pg_attribute attr);
+
+/* Returns typname, possibly with a typemod. */
+static const char*
+format_ch_type(const char* typname, Form_pg_attribute attr);
+
+/* Populates `ctx->structure` if it's not already set. */
+static void
+setup_structure(chdbCopyContext* ctx, Relation rel);
 
 /*
  * Decomposition of an Azure URL into the arguments that `azureBlobStorage()`
@@ -208,19 +223,21 @@ chdb_bgw_main(Datum main_arg) {
     cleanup.arg                   = chDBConnection;
     MemoryContextRegisterResetCallback(CurrentMemoryContext, &cleanup);
 
-    /* Assemble the chDB query. */
+    /* Start a transaction and fetch the relation. */
+    StartTransactionCommand();
+    PushActiveSnapshot(GetTransactionSnapshot());
+    Relation rel = table_open(
+        ctx->extra.rel_id, ctx->extra.is_from ? RowExclusiveLock : AccessShareLock
+    );
+
+    /* Assemble the chDB query; we always need a structure. */
+    setup_structure(ctx, rel);
     StringInfoData ch_query;
     char* names[CHDB_MAX_TABLEFUNC_ARGS];
     char* values[CHDB_MAX_TABLEFUNC_ARGS];
     size_t param_count;
     initStringInfo(&ch_query);
     param_count = make_ch_query(ctx, &ch_query, names, values);
-
-    StartTransactionCommand();
-    PushActiveSnapshot(GetTransactionSnapshot());
-    Relation rel = table_open(
-        ctx->extra.rel_id, ctx->extra.is_from ? RowExclusiveLock : AccessShareLock
-    );
 
     const char* error;
     uint64_t num_rows = 0;
@@ -229,7 +246,6 @@ chdb_bgw_main(Datum main_arg) {
      * Formats](https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table)
      */
     if (ctx->extra.is_from) {
-        // elog(NOTICE, "QUERY: %s", ch_query.data);
         /* Start streaming the chDB query. */
         chDBStreamingResult = chdb_stream_query_with_params(
             *chDBConnection,
@@ -453,19 +469,10 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         }
 
         /* Append remaining arguments and settings. */
+        PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+        PARAM(", {structure:String}", "structure", ctx->structure);
         if (ctx->compression[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(
-                ", {structure:String}",
-                "structure",
-                ctx->structure[0] ? ctx->structure : "auto"
-            );
             PARAM(", {compression:String}", "compression", ctx->compression);
-        } else if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(", {structure:String}", "structure", ctx->structure);
-        } else if (ctx->format[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
         }
         appendStringInfo(
             query,
@@ -479,13 +486,8 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
 
         /* First parameter: the base URL. */
         PARAM("{url:String}", "url", ctx->url);
-
-        if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(", {structure:String}", "structure", ctx->structure);
-        } else if (ctx->format[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
-        }
+        PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+        PARAM(", {structure:String}", "structure", ctx->structure);
         appendStringInfo(
             query,
             ") SETTINGS %s, http_connection_timeout=%u, http_max_tries=1",
@@ -512,16 +514,13 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
 
         /* Append remaining arguments (different order from the others) and
          * settings. */
-        if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(", {compression:String}", "compression", ctx->compression);
-            PARAM(", {structure:String}", "structure", ctx->structure);
-        } else if (ctx->compression[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(", {compression:String}", "compression", ctx->compression);
-        } else if (ctx->format[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
-        }
+        PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+        PARAM(
+            ", {compression:String}",
+            "compression",
+            ctx->compression[0] ? ctx->compression : "auto"
+        );
+        PARAM(", {structure:String}", "structure", ctx->structure);
         appendStringInfo(
             query,
             ") SETTINGS %s, azure_request_timeout_ms=%u",
@@ -537,19 +536,10 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         PARAM("{path:String}", "path", get_local_path_from_file_url(ctx->url));
 
         /* Append remaining arguments and settings. */
+        PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+        PARAM(", {structure:String}", "structure", ctx->structure);
         if (ctx->compression[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(
-                ", {structure:String}",
-                "structure",
-                ctx->structure[0] ? ctx->structure : "auto"
-            );
             PARAM(", {compression:String}", "compression", ctx->compression);
-        } else if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(", {structure:String}", "structure", ctx->structure);
-        } else if (ctx->format[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
         }
         appendStringInfo(query, ") SETTINGS %s", settings);
         break;
@@ -560,12 +550,8 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         PARAM("{url:String}", "url", ctx->url);
 
         /* Append remaining arguments and settings. */
-        if (ctx->structure[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
-            PARAM(", {structure:String}", "structure", ctx->structure);
-        } else if (ctx->format[0] != '\0') {
-            PARAM(", {format:String}", "format", ctx->format);
-        }
+        PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
+        PARAM(", {structure:String}", "structure", ctx->structure);
         appendStringInfo(query, ") SETTINGS %s", settings);
         break;
     default:
@@ -842,4 +828,227 @@ send_chdb_data(void* data, int len) {
             errdetail("chDB Error: %s", error)
         );
     }
+}
+
+static const char*
+chdb_type_for(Form_pg_attribute attr) {
+    switch (attr->atttypid) {
+    case BOOLOID:
+        return "Bool";
+    case BYTEAOID:
+    case NAMEOID:
+    case TEXTOID:
+    case INETOID: // Or IPv4 or IPv6
+    case CIDROID:
+    case MACADDROID:
+    case MACADDR8OID:
+    case INTERVALOID:
+    case TSVECTOROID:
+    case JSONPATHOID:
+    case MONEYOID:
+    case XMLOID:
+    case CIRCLEOID:
+    case ANYENUMOID:
+    case LINEOID:
+        return "String";
+    case VARCHAROID:
+    case VARBITOID:
+        return format_ch_type("String", attr);
+    case CHAROID:
+    case BITOID:
+        return format_ch_type("FixedString", attr);
+    case BPCHAROID:
+        return attr->atttypmod < 0 ? "String" : format_ch_type("FixedString", attr);
+    case INT8OID:
+        return "Int64";
+    case INT2OID:
+        return "Int16";
+    case INT4OID:
+        return "Int32";
+    case OIDOID:
+        return "UInt32";
+    case JSONOID:
+    case JSONBOID:
+        return "JSON";
+    case POINTOID:
+        return "Point";
+    case LSEGOID:
+    case PATHOID:
+        return "LineString";
+    case BOXOID:
+    case POLYGONOID:
+        return "Polygon";
+    case FLOAT4OID:
+        return "Float32";
+    case FLOAT8OID:
+        return "Float64";
+    case DATEOID:
+        return "Date32";
+    case TIMEOID:
+    case TIMETZOID:
+        /* Don't bother with attr->atttypmod, incompatible syntax. */
+        return "Time64";
+    case TIMESTAMPOID:
+        /* Until we can specify TZ as part of the type. */
+        return "String";
+    case TIMESTAMPTZOID:
+        /* Don't bother with attr->atttypmod, incompatible syntax. */
+        return "DateTime64";
+    case NUMERICOID:
+        return format_ch_type("Decimal", attr);
+    case UUIDOID:
+        return "UUID";
+    case OID8OID:
+        return "UInt64";
+    case BOOLARRAYOID:
+        return "Array(Bool)";
+    case BYTEAARRAYOID:
+    case NAMEARRAYOID:
+    case TEXTARRAYOID:
+    case XMLARRAYOID:
+    case MONEYARRAYOID:
+    case MACADDRARRAYOID:
+    case INETARRAYOID:
+    case CIDRARRAYOID:
+    case MACADDR8ARRAYOID:
+    case INTERVALARRAYOID:
+    case TSVECTORARRAYOID:
+    case TSQUERYARRAYOID:
+    case JSONPATHARRAYOID:
+    case CSTRINGARRAYOID:
+    case CIRCLEARRAYOID:
+    case LINEARRAYOID:
+        return "Array(String)";
+    case VARCHARARRAYOID:
+    case VARBITARRAYOID:
+        return psprintf("Array(%s)", format_ch_type("String", attr));
+    case CHARARRAYOID:
+    case BITARRAYOID:
+    case BPCHARARRAYOID:
+        return psprintf(
+            "Array(%s)",
+            attr->atttypmod < 0 ? "String" : format_ch_type("FixedString", attr)
+        );
+    case INT8ARRAYOID:
+        return "Array(Int64)";
+    case INT2ARRAYOID:
+        return "Array(Int16)";
+    case INT4ARRAYOID:
+        return "Array(Int32)";
+    case OIDARRAYOID:
+        return "Array(UInt32)";
+    case JSONARRAYOID:
+    case JSONBARRAYOID:
+        return "Array(JSON)";
+    case POINTARRAYOID:
+        return "Array(Point)";
+    case LSEGARRAYOID:
+    case PATHARRAYOID:
+        return "Array(LineString)";
+    case BOXARRAYOID:
+    case POLYGONARRAYOID:
+        return "Array(Polygon)";
+    case FLOAT4ARRAYOID:
+        return "Array(Float32)";
+    case FLOAT8ARRAYOID:
+        return "Array(Float64)";
+    case DATEARRAYOID:
+        return "Array(Date32)";
+    case TIMEARRAYOID:
+    case TIMETZARRAYOID:
+        /* Don't bother with attr->atttypmod, incompatible syntax. */
+        return "Array(Time64)";
+    case TIMESTAMPARRAYOID:
+        /* Until we can specify TZ as part of the type. */
+        return "Array(String)";
+    case TIMESTAMPTZARRAYOID:
+        /* Don't bother with attr->atttypmod, incompatible syntax. */
+        return "Array(DateTime64)";
+    case NUMERICARRAYOID:
+        return psprintf("Array(%s)", format_ch_type("Decimal", attr));
+    case UUIDARRAYOID:
+        return "Array(UUID)";
+    case OID8ARRAYOID:
+        return "Array(UInt64)";
+    default:
+        return attr->attndims ? "Array(String)" : "String";
+    }
+}
+
+/*
+ * Add typmod decoration to the basic type name. Copied from
+ * src/backend/utils/adt/format_ch_type.c in the Postgres source.
+ */
+static const char*
+format_ch_type(const char* typname, Form_pg_attribute attr) {
+    Oid pg_type     = attr->atttypid;
+    int32_t typemod = attr->atttypmod;
+    if (typemod < 0) {
+        return typname;
+    }
+    HeapTuple tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(pg_type));
+    if (!HeapTupleIsValid(tuple)) {
+        elog(ERROR, "chdb: cache lookup failed for type %u", pg_type);
+    }
+    Form_pg_type form = (Form_pg_type)GETSTRUCT(tuple);
+
+    if (form->typmodout == InvalidOid) {
+        /* Default behavior: just print the integer typmod with parens */
+        return psprintf("%s(%d)", typname, typemod);
+    }
+
+    /* Use the type-specific typmodout procedure */
+    return psprintf(
+        "%s%s",
+        typname,
+        DatumGetCString(OidFunctionCall1(form->typmodout, Int32GetDatum(typemod)))
+    );
+}
+
+/*
+ * Setup `ctx->structure` if none is provided. Builds it from the columns in
+ * the relation to be copied.
+ */
+static void
+setup_structure(chdbCopyContext* ctx, Relation rel) {
+    if (ctx->structure[0] != '\0') {
+        return;
+    }
+
+    StringInfoData buf;
+    initStringInfo(&buf);
+    TupleDesc tupDesc = RelationGetDescr(rel);
+    int attr_count    = tupDesc->natts;
+    bool first        = true;
+
+    for (int i = 0; i < attr_count; i++) {
+        Form_pg_attribute attr = TupleDescAttr(tupDesc, i);
+        if (attr->attisdropped || attr->attgenerated) {
+            continue;
+            ;
+        }
+
+        if (first) {
+            first = false;
+        } else {
+            appendStringInfoString(&buf, ", ");
+        }
+
+        if (attr->attndims && !attr->attnotnull) {
+            /* chDB doesn't supported a nullable array, so just use a string. */
+            appendStringInfo(
+                &buf, "%s String", quote_identifier(NameStr(attr->attname))
+            );
+        } else {
+            appendStringInfo(
+                &buf,
+                "%s %s%s",
+                quote_identifier(NameStr(attr->attname)),
+                chdb_type_for(attr),
+                attr->attnotnull ? "" : " NULL"
+            );
+        }
+    }
+
+    ctx->structure = buf.data;
 }

--- a/src/hook.c
+++ b/src/hook.c
@@ -358,8 +358,7 @@ ProcessMessages(shm_mq_handle* queue, QueryCompletion* qc) {
         case PqMsg_Progress: {
             /* Progress report. See pgstat_progress_parallel_incr_param for format. */
             (void)pq_getmsgint(&msg, sizeof(uint32_t)); /* unused for now */
-            qc->nprocessed = pq_getmsgint64(&msg);
-            qc->commandTag = CMDTAG_COPY;
+            SetQueryCompletion(qc, CMDTAG_COPY, pq_getmsgint64(&msg));
             resetStringInfo(&msg);
             break;
         }

--- a/t/chDBTestUtils.pm
+++ b/t/chDBTestUtils.pm
@@ -1,0 +1,67 @@
+package chDBTestUtils;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+our @EXPORT = qw(bgw_log check_log check_query);
+
+=begin chdb_bgw
+
+Fetch chdb_bgw log lines since the last fetch.
+
+=cut
+
+{
+    my $offset = 0;
+    sub bgw_log($) {
+        my $node = shift;
+        my $data = slurp_file $node->logfile, $offset;
+        $offset += length $data;
+        return grep { /\bchdb_bgw\b/ } split /\n/, $data
+            if $node->pg_version > 19;
+        return split /\n/, $data
+    }
+}
+
+=head2 check_log
+
+Compare hdb_bgw log lines immediately following a "executing chDB query" log
+line. The first should contain the chDB query with placeholders. The second
+should map the placeholders to values.
+
+=cut
+
+sub check_log {
+    my ($file, $desc, $query_rx, $params_rx) = @_;
+    my @lines = bgw_log $file;
+    while (@lines && $lines[0] !~ /executing chDB query/) {
+        shift @lines;
+    }
+
+    shift @lines;
+    splice @lines, 2;
+    is @lines, 2, "Should have 2 $desc log lines" || return;
+    like $lines[0], $query_rx, "Should match $desc query";
+    like $lines[1], $params_rx, "Should match $desc params";
+}
+
+=head2 check_query
+
+Run a subtest to validate that a given query's log values containing the
+resulting chDB query and associated parameters.
+
+=cut
+
+sub check_query {
+    my ($node, $desc, $query, $err_rx, @args) = @_;
+    subtest $desc => sub {
+        eval { $node->safe_psql(postgres => $query) };
+        like $@, $err_rx, "Should have $desc chDB error";
+        check_log $node, $desc, @args;
+    };
+}
+
+1;

--- a/t/structure.pl
+++ b/t/structure.pl
@@ -1,0 +1,451 @@
+#!/usr/bin/perl
+
+use v5.34;
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+use lib 't';
+use chDBTestUtils;
+
+my $node = PostgreSQL::Test::Cluster->new('structure');
+$node->init;
+$node->append_conf(
+    'postgresql.conf',
+    qq{shared_preload_libraries = 'chdb'\nlog_min_messages = DEBUG1},
+);
+$node->start;
+END { $node->stop('fast') }
+
+$node->safe_psql(postgres => 'CREATE EXTENSION chdb');
+my $port = PostgreSQL::Test::Cluster::get_free_port;
+my $dir = $node->basedir;
+
+NUMBERS: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE numbers (
+            i2  INT2    NOT NULL,
+            i4  INT4    NOT NULL,
+            i8  INT8        NULL,
+            num numeric     NULL,
+            f4  float4  NOT NULL,
+            f8  float8      NULL,
+            b   bool    NOT NULL,
+            o   OID     NOT NULL,
+            o8  OID8    NOT NULL
+        )
+    });
+    check_query(
+        $node, 'numbers',
+        qq{COPY numbers FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 UInt64" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE number_arrays (
+            i2  INT2[]    NOT NULL,
+            i4  INT4[]    NOT NULL,
+            i8  INT8[]    NOT NULL,
+            num numeric[] NOT NULL,
+            f4  float4[]  NOT NULL,
+            f8  float8[]  NOT NULL,
+            b   bool[]    NOT NULL,
+            o   OID[]     NOT NULL,
+            o8  OID8[]    NOT NULL
+        )
+    });
+    check_query(
+        $node, 'number arrays',
+        qq{COPY number_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "i2 Array(Int16), i4 Array(Int32), i8 Array(Int64), num Array(Decimal), f4 Array(Float32), f8 Array(Float64), b Array(Bool), o Array(UInt32), o8 Array(UInt64)" }],
+    );
+}
+
+STRINGS: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE strings (
+            t  TEXT    NOT NULL,
+            ba BYTEA   NOT NULL,
+            n  NAME        NULL
+        )
+    });
+    check_query(
+        $node, 'strings',
+        qq{COPY strings FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "t String, ba String, n String NULL" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE string_arrays (
+            t  TEXT[]    NOT NULL,
+            ba BYTEA[]   NOT NULL,
+            n  NAME[]    NOT NULL
+        )
+    });
+    check_query(
+        $node, 'string arrays',
+        qq{COPY string_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "t Array(String), ba Array(String), n Array(String)" }],
+    );
+}
+
+FIXIES: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE fixies (
+            cr  character(6) NOT NULL,
+            ch  char(12)     NOT NULL,
+            bp  bpchar       NOT NULL,
+            pbn bpchar(8)    NOT NULL
+        )
+    });
+    check_query(
+        $node, 'fixed strings',
+        qq{COPY fixies FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "cr FixedString(6), ch FixedString(12), bp String, pbn FixedString(8)" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE fixie_arrays (
+            cr  character(6)[] NOT NULL,
+            ch  char(12)[]     NOT NULL,
+            bp  bpchar[]       NOT NULL,
+            pbn bpchar(8)[]    NOT NULL
+        )
+    });
+    check_query(
+        $node, 'fixed string arrays',
+        qq{COPY fixie_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "cr Array(FixedString(6)), ch Array(FixedString(12)), bp Array(String), pbn Array(FixedString(8))" }],
+    );
+}
+
+AS_STRINGS: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE non_strings (
+            ival INTERVAL NOT NULL,
+            tsv  tsvector NOT NULL,
+            tsq  tsquery  NOT NULL,
+            jp   jsonpath NOT NULL,
+            mon  money    NOT NULL,
+            xml  XML      NOT NULL,
+            cir  circle   NOT NULL,
+            na   int[]       NULL
+        )
+    });
+    check_query(
+        $node, 'non strings as strings',
+        qq{COPY non_strings FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "ival String, tsv String, tsq String, jp String, mon String, xml String, cir String, na String" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE non_string_arrays (
+            ival INTERVAL[] NOT NULL,
+            tsv  tsvector[] NOT NULL,
+            tsq  tsquery[]  NOT NULL,
+            jp   jsonpath[] NOT NULL,
+            mon  money[]    NOT NULL,
+            xml  XML[]      NOT NULL,
+            cir  circle[]   NOT NULL,
+            na   int[]          NULL
+        )
+    });
+    check_query(
+        $node, 'no strings as string arrays',
+        qq{COPY non_string_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "ival Array(String), tsv Array(String), tsq Array(String), jp Array(String), mon Array(String), xml Array(String), cir Array(String), na String" }],
+    );
+}
+
+VARCHAR: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE varchars (
+            vc  VARCHAR    NOT NULL,
+            vcn VARCHAR(8) NOT NULL,
+            bc  VARBIT     NOT NULL,
+            bcn VARBIT(4)  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'varchars',
+        qq{COPY varchars FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "vc String, vcn String(8), bc String, bcn String(4)" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE varchar_arrays (
+            vc  VARCHAR[]    NOT NULL,
+            vcn VARCHAR(8)[] NOT NULL,
+            bc  VARBIT[]     NOT NULL,
+            bcn VARBIT(4)[]  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'varchar arrayss',
+        qq{COPY varchar_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "vc Array(String), vcn Array(String(8)), bc Array(String), bcn Array(String(4))" }],
+    );
+}
+
+JSON_UUID: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE json_uuid (
+            u  UUID   NOT NULL,
+            j  JSON   NOT NULL,
+            jb JSONB      NULL
+        )
+    });
+    check_query(
+        $node, 'json & uuid',
+        qq{COPY json_uuid FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "u UUID, j JSON, jb JSON NULL" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE json_uuid_arrays (
+            u  UUID[]   NOT NULL,
+            j  JSON[]   NOT NULL,
+            jb JSONB[]  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'json & uuid arrays',
+        qq{COPY json_uuid_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "u Array(UUID), j Array(JSON), jb Array(JSON)" }],
+    );
+}
+
+GEO: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE geos (
+            p   point    NOT NULL,
+            line line    NOT NULL,
+            lseg lseg    NOT NULL,
+            box  box     NOT NULL,
+            path path    NOT NULL,
+            poly polygon NOT NULL,
+            cir  circle  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'geometric',
+        qq{COPY geos FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "p Point, line String, lseg LineString, box Polygon, path LineString, poly Polygon, cir String" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE geo_arrays (
+            p   point[]    NOT NULL,
+            line line[]    NOT NULL,
+            lseg lseg[]    NOT NULL,
+            box  box[]     NOT NULL,
+            path path[]    NOT NULL,
+            poly polygon[] NOT NULL,
+            cir  circle[]  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'geometric arrays',
+        qq{COPY geo_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "p Array(Point), line Array(String), lseg Array(LineString), box Array(Polygon), path Array(LineString), poly Array(Polygon), cir Array(String)" }],
+    );
+}
+
+DATETIME: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE datetime (
+            ts    TIMESTAMP          NULL,
+            tsn   TIMESTAMP(3)       NULL,
+            tstz  TIMESTAMPTZ    NOT NULL,
+            tstzn TIMESTAMPTZ(4) NOT NULL,
+            date  DATE           NOT NULL,
+            time  TIME           NOT NULL,
+            timen TIME(3)        NOT NULL,
+            ttz   TIMETZ         NOT NULL,
+            ttzn  TIMETZ(3)      NOT NULL,
+            ival  INTERVAL       NOT NULL
+        )
+    });
+    check_query(
+        $node, 'datetime',
+        qq{COPY datetime FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "ts String NULL, tsn String NULL, tstz DateTime64, tstzn DateTime64, date Date32, "time" Time64, timen Time64, ttz Time64, ttzn Time64, ival String" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE datetime_arrays (
+            ts    TIMESTAMP[]      NOT NULL,
+            tsn   TIMESTAMP(3)[]   NOT NULL,
+            tstz  TIMESTAMPTZ[]    NOT NULL,
+            tstzn TIMESTAMPTZ(4)[] NOT NULL,
+            date  DATE[]           NOT NULL,
+            time  TIME[]           NOT NULL,
+            timen TIME(3)[]        NOT NULL,
+            ttz   TIMETZ[]         NOT NULL,
+            ttzn  TIMETZ(3)[]      NOT NULL,
+            ival  INTERVAL[]       NOT NULL
+        )
+    });
+    check_query(
+        $node, 'datetime arrays',
+        qq{COPY datetime_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "ts Array(String), tsn Array(String), tstz Array(DateTime64), tstzn Array(DateTime64), date Array(Date32), "time" Array(Time64), timen Array(Time64), ttz Array(Time64), ttzn Array(Time64), ival Array(String)" }],
+    );
+}
+
+ENUMS: {
+    $node->safe_psql(postgres => q{
+        CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+    });
+    $node->safe_psql(postgres => q{
+        CREATE TYPE dow AS ENUM ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat');
+    });
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE enums (
+            mood mood NOT NULL,
+            dow  dow  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'enums',
+        qq{COPY enums FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "mood String, dow String" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE enum_arrays (
+            mood mood[] NOT NULL,
+            dow  dow[]  NOT NULL
+        )
+    });
+    check_query(
+        $node, 'enum arrays',
+        qq{COPY enum_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "mood Array(String), dow Array(String)" }],
+    );
+}
+
+NETS: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE nets (
+            inet INET     NOT NULL,
+            cidr CIDR     NOT NULL,
+            mac  MACADDR  NOT NULL,
+            mac8 MACADDR8 NOT NULL
+        )
+    });
+    check_query(
+        $node, 'network addresses',
+        qq{COPY nets FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "inet String, cidr String, mac String, mac8 String" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE net_arrays (
+            inet INET[]     NOT NULL,
+            cidr CIDR[]     NOT NULL,
+            mac  MACADDR[]  NOT NULL,
+            mac8 MACADDR8[] NOT NULL
+        )
+    });
+    check_query(
+        $node, 'network address arrays',
+        qq{COPY net_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "inet Array(String), cidr Array(String), mac Array(String), mac8 Array(String)" }],
+    );
+}
+
+BITS: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE bits (
+            b  BIT       NOT NULL,
+            bn BIT(3)    NOT NULL,
+            vb varbit(6) NOT NULL
+
+        )
+    });
+    check_query(
+        $node, 'bit strings',
+        qq{COPY bits FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "b FixedString(1), bn FixedString(3), vb String(6)" }],
+    );
+
+    $node->safe_psql(postgres => q{
+        CREATE TABLE bit_arrays (
+            b  BIT[]       NOT NULL,
+            bn BIT(3)[]    NOT NULL,
+            vb varbit(6)[] NOT NULL
+
+        )
+    });
+    check_query(
+        $node, 'bit string arrays',
+        qq{COPY bit_arrays FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: "b Array(FixedString(1)), bn Array(FixedString(3)), vb Array(String(6))" }],
+    );
+}
+
+NAMING: {
+    $node->safe_psql(postgres => q{
+        CREATE TABLE "Namings" (
+            "ID"        INT  NOT NULL,
+            "Full Name" TEXT NOT NULL
+        )
+    });
+
+    check_query(
+        $node, 'quote identifiers',
+        qq{COPY "Namings" FROM 'file://$dir/nonesuch.csv'},
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file],
+        qr[\Q structure: ""ID" Int32, "Full Name" String" }],
+    );
+}
+
+done_testing;

--- a/t/table-functions.pl
+++ b/t/table-functions.pl
@@ -6,51 +6,10 @@ use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
+use lib 't';
+use chDBTestUtils;
 
 my $node = PostgreSQL::Test::Cluster->new('table-functions');
-
-# Set up utility test functions.
-{
-    # Fetch chdb_bgw log lines from offset.
-    my $offset = 0;
-    sub bgw_log($) {
-        my $node = shift;
-        my $data = slurp_file $node->logfile, $offset;
-        $offset += length $data;
-        return grep { /\bchdb_bgw\b/ } split /\n/, $data
-            if $node->pg_version > 19;
-        return split /\n/, $data
-    }
-}
-
-# Compare hdb_bgw log lines immediately following a "executing chDB query" log
-# line. The first should contain the chDB query with placeholders. The second
-# should map the placeholders to values.
-sub check_log {
-    my ($file, $desc, $query_rx, $params_rx) = @_;
-    my @lines = bgw_log $file;
-    while (@lines && $lines[0] !~ /executing chDB query/) {
-        shift @lines;
-    }
-
-    shift @lines;
-    splice @lines, 2;
-    is @lines, 2, "Should have 2 $desc log lines" || return;
-    like $lines[0], $query_rx, "Should match $desc query";
-    like $lines[1], $params_rx, "Should match $desc params";
-}
-
-# Test a given query's log values containing the resulting chDB query and
-# associated parameters.
-sub check_query {
-    my ($node, $desc, $query, @args) = @_;
-    subtest $desc => sub {
-        eval { $node->safe_psql(postgres => $query) };
-        ok $@, "Should have $desc chDB error";
-        check_log $node, $desc, @args;
-    };
-}
-
 $node->init;
 $node->append_conf(
     'postgresql.conf',
@@ -67,14 +26,16 @@ subtest s3 => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 's3://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QSELECT * FROM s3({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
-        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv" }],
+        qr/\QHTTP response code: 403/,
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
+        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 's3://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QINSERT INTO FUNCTION s3('s3://localhost\E:$port\Q/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
-        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv" }],
+        qr/\QFailed to receive table structure/,
+        qr[\QINSERT INTO FUNCTION s3('s3://localhost\E:$port\Q/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
+        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'FROM all params',
@@ -89,6 +50,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
+        qr/\QHTTP response code: 403/,
         qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", session_token: "big fat token", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
@@ -104,6 +66,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
+        qr/\QHTTP response code: 403/,
         qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "", session_token: "some token", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
@@ -118,6 +81,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
+        qr/\QHTTP response code: 403/,
         qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
@@ -130,6 +94,7 @@ subtest s3 => sub {
                 timeout 0
             )
         },
+        qr/\QHTTP response code: 403/,
         qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "id Int64" }],
     );
@@ -142,8 +107,9 @@ subtest s3 => sub {
                 timeout 0
             )
         },
+        qr/\QHTTP response code: 403/,
         qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
-        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "auto", compression: "snappy" }],
+        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "id Int32 NULL", compression: "snappy" }],
     );
     check_query(
         $node, 'FROM with no format',
@@ -153,8 +119,9 @@ subtest s3 => sub {
                 timeout 0
             )
         },
+        qr/\QHTTP response code: 403/,
         qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
-        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "auto", compression: "snappy" }],
+        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL", compression: "snappy" }],
     );
     check_query(
         $node, 'FROM with just format',
@@ -164,8 +131,9 @@ subtest s3 => sub {
                 timeout 100
             )
         },
-        qr[\QSELECT * FROM s3({url:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 100],
-        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "tsv" }],
+        qr/\QHTTP response code: 403/,
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 100],
+        qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "tsv", structure: "id Int32 NULL" }],
     );
 };
 
@@ -174,14 +142,16 @@ subtest gcs => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'gcs://example.org/bucket/prefix/file.csv'},
-        qr[\QSELECT * FROM gcs({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
-        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv" }],
+        qr/HTTP response code: 404/,
+        qr[\QSELECT * FROM gcs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
+        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'gcs://example.org/bucket/prefix/file.csv'},
-        qr[\QINSERT INTO FUNCTION gcs('https://example.org/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
-        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv" }],
+        qr/chDB Error: Code: 499/,
+        qr[\QINSERT INTO FUNCTION gcs('https://example.org/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
+        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'FROM all params',
@@ -196,6 +166,7 @@ subtest gcs => sub {
                 timeout 0
             )
         },
+        qr/HTTP response code: 404/,
         qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
@@ -207,32 +178,37 @@ subtest http => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'http://example.org/path/file.csv'},
-        qr[\QSELECT * FROM url({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
-        qr[\Q{ url: "http://example.org/path/file.csv" }],
+        qr/HTTP status code: 404/,
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
+        qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'http://example.org/path/file.csv'},
-        qr[\QINSERT INTO FUNCTION url('http://example.org/path/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
-        qr[\Q{ url: "http://example.org/path/file.csv" }],
+        qr/^$/, # XXX Why doesn't this fail?
+        qr[\QINSERT INTO FUNCTION url('http://example.org/path/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
+        qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
-        $node, 'TO format, structure, round up timeout',
+        $node, 'FROM format, structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (FORMAT 'TabSeparated', structure 'id Int32', timeout 500)},
+        qr/HTTP status code: 404/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "TabSeparated", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (structure 'id Int32', timeout 1500)},
+        qr/HTTP status code: 404/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=2, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO format',
-        qq{COPY stuff FROM 'http://example.org/path/file.csv' (format 'x UInt16', timeout 100)},
-        qr[\QSELECT * FROM url({url:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
-        qr[\Q{ url: "http://example.org/path/file.csv", format: "x UInt16" }],
+        qq{COPY stuff FROM 'http://example.org/path/file.csv' (format 'CSV', timeout 100)},
+        qr/HTTP status code: 404/,
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
+        qr[\Q{ url: "http://example.org/path/file.csv", format: "CSV", structure: "id Int32 NULL" }],
     );
 };
 
@@ -266,20 +242,23 @@ subtest azure => sub {
     check_query(
         $node, 'just FROM azure',
         q{COPY stuff FROM 'az://example.org/path/file.csv'},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
-        qr[\Q{ url: "https://example.org", container: "path", path: "file.csv", account_name: "", account_key: "" }],
+        qr/Azure::Storage::StorageException: 404 Not Found/,
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
+        qr[\Q{ url: "https://example.org", container: "path", path: "file.csv", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'To azure with query',
         q{COPY stuff TO 'az://example.org/path/file.csv?x=y&abc=12'},
-        qr[\QINSERT INTO FUNCTION azureBlobStorage('https://example.org?x=y&abc=12', 'path', 'file.csv', '', '') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
-        qr[\Q{ url: "https://example.org?x=y&abc=12", container: "path", path: "file.csv", account_name: "", account_key: "" }],
+        qr/Failed to receive table structure/, # XXX az just borked
+        qr[\QINSERT INTO FUNCTION azureBlobStorage('https://example.org?x=y&abc=12', 'path', 'file.csv', '', '', 'auto', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
+        qr[\Q{ url: "https://example.org?x=y&abc=12", container: "path", path: "file.csv", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'FROM azure with no path',
         q{COPY stuff FROM 'az://example.org/container'},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
-        qr[\Q{ url: "https://example.org", container: "container", path: "", account_name: "", account_key: "" }],
+        qr/The data format cannot be detected by the contents/, # XXX az just borked
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
+        qr[\Q{ url: "https://example.org", container: "container", path: "", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'FROM Azure with all args',
@@ -294,6 +273,7 @@ subtest azure => sub {
                 timeout 200
             )
         },
+        qr/Unexpected end of Base64 encoded string/, # XXX az just borked
         qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=200],
         qr[\Q{ url: "https://acc.example.org", container: "xyz", path: "yep.csv", account_name: "ac_name", account_key: "ac_key", format: "tsv", compression: "lz4", structure: "id Int32" }],
     );
@@ -301,6 +281,7 @@ subtest azure => sub {
     check_query(
         $node, 'FROM abfs with compression & structure',
         q{COPY stuff FROM 'abfs://container@account/xyz/yep.csv' (access_key 'ac-key', compression 'snappy', structure 'x String')},
+        qr/403 The specified account is disabled/,
         qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://account.blob.core.windows.net", container: "container", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "snappy", structure: "x String" }],
     );
@@ -308,15 +289,17 @@ subtest azure => sub {
     check_query(
         $node, 'FROM abfss host with structure',
         q{COPY stuff FROM 'abfss://hi@example.org/xyz/yep.csv' (access_key 'ac-key', structure 'x String')},
+        qr/Azure::Storage::StorageException: 404 Not Found/,
         qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
-        qr[\Q{ url: "https://example.org", container: "hi", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "", structure: "x String" }],
+        qr[\Q{ url: "https://example.org", container: "hi", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "auto", structure: "x String" }],
     );
 
     check_query(
         $node, 'FROM no-path abfs with format only',
-        q{COPY stuff FROM 'abfs://slick@example.org' (format 'z Int8')},
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
-        qr[\Q{ url: "https://example.org", container: "slick", path: "", account_name: "", account_key: "", format: "z Int8" }],
+        q{COPY stuff FROM 'abfs://slick@example.org' (format 'TSV')},
+        qr/Azure::Storage::StorageException: 404 Not Found/,
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
+        qr[\Q{ url: "https://example.org", container: "slick", path: "", account_name: "", account_key: "", format: "TSV", compression: "auto", structure: "id Int32 NULL" }],
     );
 };
 
@@ -331,55 +314,66 @@ subtest file => sub {
     check_query(
         $node, 'just FROM file',
         qq{COPY stuff FROM 'file://$dir/nonesuch.csv'},
-        qr[\QSELECT * FROM file({path:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
-        qr[\Q{ path: "$dir/nonesuch.csv" }],
-    );
-
-    check_query(
-        $node, 'just TO file',
-        qq{COPY stuff TO 'file://$dir/nonesuch.csv'},
-        qr[\QINSERT INTO FUNCTION file('$dir/nonesuch.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
-        qr[\Q{ path: "$dir/nonesuch.csv" }],
+        qr/nonesuch.csv doesn't exist/,
+        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr[\Q{ path: "$dir/nonesuch.csv", format: "auto", structure: "id Int32 NULL" }],
     );
 
     check_query(
         $node, 'all options',
         qq{COPY stuff FROM 'file://$dir/nonesuch.csv' (compression 'lz4', structure 'z Int8', format 'tsv')},
+        qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv", format: "tsv", structure: "z Int8", compression: "lz4" }],
     );
+
+    check_query(
+        $node, 'just TO file',
+        qq{COPY stuff TO 'file://$dir/nonesuch.csv'},
+        qr/^$/,
+        qr[\QINSERT INTO FUNCTION file('$dir/nonesuch.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr[\Q{ path: "$dir/nonesuch.csv", format: "auto", structure: "id Int32 NULL" }],
+    );
+
+    is slurp_file("$dir/nonesuch.csv"), '', 'File should exist but be empty';
 };
 
 subtest hdfs => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QSELECT * FROM hdfs({url:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
-        qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv" }],
+        qr/Unknown table function hdfs/, # XXX WTF
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
+
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'hdfs://localhost:$port/bucket/prefix/file.csv'},
-        qr[\QINSERT INTO FUNCTION hdfs('hdfs://localhost:\E$port\Q/bucket/prefix/file.csv') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
-        qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv" }],
+        qr/Failed to receive table structure/, # XXX WTF
+        qr[\QINSERT INTO FUNCTION hdfs('hdfs://localhost:\E$port\Q/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'FROM url with format and structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (FORMAT 'TSV', STRUCTURE 'a Int8')},
+        qr/Unknown table function hdfs/, # XXX WTF
         qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TSV", structure: "a Int8" }],
     );
     check_query(
         $node, 'FROM url with structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (STRUCTURE 'a UInt8')},
+        qr/Unknown table function hdfs/, # XXX WTF
         qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "a UInt8" }],
     );
     check_query(
         $node, 'FROM url with format',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (format 'TabSeparated')},
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
-        qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TabSeparated" }],
+        qr/Unknown table function hdfs/, # XXX WTF
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TabSeparated", structure: "id Int32 NULL" }],
     );
 };
 

--- a/test/corpus/people.tsv
+++ b/test/corpus/people.tsv
@@ -3,5 +3,5 @@
 3	Gates	Bill	Dos\r\nWindows\r\nExplorer
 4	Matrix	Dot	a \f b \f c \f \b
 5	Language	C	\N
-6 	Others 	Some	go \\ get \a your \v mouse \x40
+6	Others	Some	go \\ get \a your \v mouse \x40
 7	Others	Some	go \\ get  your  mouse @

--- a/test/expected/file.out
+++ b/test/expected/file.out
@@ -68,7 +68,7 @@ COPY 7
 3	Gates	Bill	Dos\r\nWindows\r\nExplorer
 4	Matrix	Dot	a \f b \f c \f \b
 5	Language	C	\N
-6	Others 	Some	go \\ get  your  mouse @
+6	Others	Some	go \\ get  your  mouse @
 7	Others	Some	go \\ get  your  mouse @
 -- Import it again;
 TRUNCATE people;
@@ -99,6 +99,6 @@ COPY 7
 3	Gates	Bill	Dos\r\nWindows\r\nExplorer
 4	Matrix	Dot	a \f b \f c \f \b
 5	Language	C	\N
-6	Others 	Some	go \\ get  your  mouse @
+6	Others	Some	go \\ get  your  mouse @
 7	Others	Some	go \\ get  your  mouse @
 \! rm -rf test/file.tmp


### PR DESCRIPTION
When the user doesn't provide a `structure` argument to `COPY`, build one from the table being copied. This allows more intelligent storage and representation and interpretation of data in chDB. It's likely imperfect; I expect arrays, in particular, to be a challenge, and may well map more types to `String` to avoid issues in a future commit.

The new `setup_structure()` function handles this behavior, delegating to `chdb_type_for()` to format the types for chDB, and to `format_ch_type()` to handle typedefs where appropriate.

With the structure always set, simplify the settings of the params in `make_ch_query()`.

In the process, found wayward spaces for integer fields in `test/corpus/people.tsv`, so fix those, and also add the structure to the expected parameters inspected by `t/table-functions.pl`. Then add a
 new Tap test, `t/structure.pl`, to ensure that data types are properly
mapped. Since it shares code with `t/table-functions.pl`, move the common functions to a module, `chDBTestUtils`.

While at it, use `SetQueryCompletion()` to report copy completion, rather than set attributes directly.