### PR TITLE
Test and fix type compatibility

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -196,6 +196,21 @@ chdb_bgw_main(Datum main_arg) {
 #endif
     );
 
+    /*
+     * Set the client encoding to the database encoding, since that is what
+     * the parent will expect. (We're cheating a bit by not calling
+     * PrepareClientEncoding first. It's okay because this call will always
+     * result in installing a no-op conversion. No error should be possible,
+     * but check anyway.)
+     */
+    if (SetClientEncoding(GetDatabaseEncoding()) < 0) {
+        elog(ERROR, "SetClientEncoding(%d) failed", GetDatabaseEncoding());
+    }
+
+    /* We always want to use ISO date style and UTC time zone. */
+    SetConfigOption("datestyle", "ISO", PGC_BACKEND, PGC_S_SESSION);
+    SetConfigOption("timezone", "UTC", PGC_BACKEND, PGC_S_SESSION);
+
     /* Check our globals. */
     Assert(chDBConnection == NULL);
     Assert(chDBStreamingResult == NULL);
@@ -858,7 +873,12 @@ chdb_type_for(Form_pg_attribute attr) {
     case BITOID:
         return format_ch_type("FixedString", attr);
     case BPCHAROID:
-        return attr->atttypmod < 0 ? "String" : format_ch_type("FixedString", attr);
+        /* For Postgres the typedef is number of characters while for chDB
+         * FixedString it's bytes. Format it as a chDB String to prevent it
+         * from failing on multibyte characters.
+         */
+        return format_ch_type("String", attr);
+        // return attr->atttypmod < 0 ? "String" : format_ch_type("FixedString", attr);
     case INT8OID:
         return "Int64";
     case INT2OID:
@@ -869,39 +889,64 @@ chdb_type_for(Form_pg_attribute attr) {
         return "UInt32";
     case JSONOID:
     case JSONBOID:
-        return "JSON";
+        /* chDB JSON limited to objects, sadly. */
+        // return "JSON";
+        return "String";
     case POINTOID:
         return "Point";
     case LSEGOID:
     case PATHOID:
-        return "LineString";
+        /* chDB uses brackets rather than parens. */
+        // return "LineString";
+        return "String";
     case BOXOID:
     case POLYGONOID:
-        return "Polygon";
+        /* chDB uses brackets rather than parens. */
+        // return "Polygon";
+        return "String";
     case FLOAT4OID:
+        /* Disallows NaN, Infinity, -Infinity. */
         return "Float32";
     case FLOAT8OID:
+        /* Disallows NaN, Infinity, -Infinity. */
         return "Float64";
     case DATEOID:
         return "Date32";
     case TIMEOID:
-    case TIMETZOID:
         /* Don't bother with attr->atttypmod, incompatible syntax. */
-        return "Time64";
+        return "Time64(6)";
+    case TIMETZOID:
+        /*
+         * ClickHouse doesn't support time with time zone, and Postgres
+         * recommends against it anyway. Serialize as a string.
+         */
+        return "String";
     case TIMESTAMPOID:
         /* Until we can specify TZ as part of the type. */
         return "String";
     case TIMESTAMPTZOID:
         /* Don't bother with attr->atttypmod, incompatible syntax. */
-        return "DateTime64";
+        // return format_ch_type("DateTime64", attr);
+        return "DateTime64(6, 'UTC')";
     case NUMERICOID:
-        return format_ch_type("Decimal", attr);
+        /*
+         * Unconstrained numeric potentially much larger than ClickHouse can
+           do; max it out when no precision specified.
+        */
+        return attr->atttypmod < 1 ? "Decimal256(38)" : format_ch_type("Decimal", attr);
     case UUIDOID:
         return "UUID";
     case OID8OID:
         return "UInt64";
+    /*
+     * Arrays: chDB TSV array format differs from Postgres. Perhaps it'd make
+     * sense to adopt the binary format instead and convert things properly,
+     * like pg_clickhouse does. But since output formats like Parquet don't
+     * support arrays, anyway, just always make them strings. Comments with
+     * actual array types left for future reference.
+     */
     case BOOLARRAYOID:
-        return "Array(Bool)";
+        // return "Array(Bool)";
     case BYTEAARRAYOID:
     case NAMEARRAYOID:
     case TEXTARRAYOID:
@@ -918,60 +963,70 @@ chdb_type_for(Form_pg_attribute attr) {
     case CSTRINGARRAYOID:
     case CIRCLEARRAYOID:
     case LINEARRAYOID:
-        return "Array(String)";
+        // return "Array(String)";
     case VARCHARARRAYOID:
     case VARBITARRAYOID:
-        return psprintf("Array(%s)", format_ch_type("String", attr));
+        // return psprintf("Array(%s)", format_ch_type("String", attr));
     case CHARARRAYOID:
     case BITARRAYOID:
     case BPCHARARRAYOID:
-        return psprintf(
-            "Array(%s)",
-            attr->atttypmod < 0 ? "String" : format_ch_type("FixedString", attr)
-        );
+        // return psprintf(
+        //     "Array(%s)",
+        //     attr->atttypmod < 0 ? "String" : format_ch_type("FixedString", attr)
+        // );
     case INT8ARRAYOID:
-        return "Array(Int64)";
+        // return "Array(Int64)";
     case INT2ARRAYOID:
-        return "Array(Int16)";
+        // return "Array(Int16)";
     case INT4ARRAYOID:
-        return "Array(Int32)";
+        // return "Array(Int32)";
     case OIDARRAYOID:
-        return "Array(UInt32)";
+        // return "Array(UInt32)";
     case JSONARRAYOID:
     case JSONBARRAYOID:
-        return "Array(JSON)";
+        // return "Array(JSON)";
     case POINTARRAYOID:
-        return "Array(Point)";
+        // return "Array(Point)";
     case LSEGARRAYOID:
     case PATHARRAYOID:
-        return "Array(LineString)";
+        // return "Array(LineString)";
     case BOXARRAYOID:
     case POLYGONARRAYOID:
-        return "Array(Polygon)";
+        // return "Array(Polygon)";
     case FLOAT4ARRAYOID:
-        return "Array(Float32)";
+        // return "Array(Float32)";
     case FLOAT8ARRAYOID:
-        return "Array(Float64)";
+        // return "Array(Float64)";
     case DATEARRAYOID:
-        return "Array(Date32)";
+        // return "Array(Date32)";
     case TIMEARRAYOID:
     case TIMETZARRAYOID:
         /* Don't bother with attr->atttypmod, incompatible syntax. */
-        return "Array(Time64)";
+        // return "Array(Time64)";
     case TIMESTAMPARRAYOID:
         /* Until we can specify TZ as part of the type. */
-        return "Array(String)";
+        // return "Array(String)";
     case TIMESTAMPTZARRAYOID:
         /* Don't bother with attr->atttypmod, incompatible syntax. */
-        return "Array(DateTime64)";
+        // return "Array(DateTime64)";
     case NUMERICARRAYOID:
-        return psprintf("Array(%s)", format_ch_type("Decimal", attr));
+        // return psprintf(
+        //     "Array(%s)",
+        //     attr->atttypmod < 1 ? "Decimal256(38)" : format_ch_type("Decimal",
+        //     attr)
+        // );
     case UUIDARRAYOID:
-        return "Array(UUID)";
+        // return "Array(UUID)";
     case OID8ARRAYOID:
-        return "Array(UInt64)";
+        /*
+         * Type to use for all arrays for now. Uncomment // lines above and in
+         * default: to specify proper array types once we've managed to make
+         * the compatible.
+         */
+        return "String";
     default:
-        return attr->attndims ? "Array(String)" : "String";
+        // return attr->attndims ? "Array(String)" : "String";
+        return "String";
     }
 }
 
@@ -994,15 +1049,18 @@ format_ch_type(const char* typname, Form_pg_attribute attr) {
 
     if (form->typmodout == InvalidOid) {
         /* Default behavior: just print the integer typmod with parens */
+        ReleaseSysCache(tuple);
         return psprintf("%s(%d)", typname, typemod);
     }
 
     /* Use the type-specific typmodout procedure */
-    return psprintf(
+    char* result = psprintf(
         "%s%s",
         typname,
         DatumGetCString(OidFunctionCall1(form->typmodout, Int32GetDatum(typemod)))
     );
+    ReleaseSysCache(tuple);
+    return result;
 }
 
 /*
@@ -1025,7 +1083,6 @@ setup_structure(chdbCopyContext* ctx, Relation rel) {
         Form_pg_attribute attr = TupleDescAttr(tupDesc, i);
         if (attr->attisdropped || attr->attgenerated) {
             continue;
-            ;
         }
 
         if (first) {

--- a/t/structure.pl
+++ b/t/structure.pl
@@ -25,15 +25,17 @@ my $dir = $node->basedir;
 NUMBERS: {
     $node->safe_psql(postgres => q{
         CREATE TABLE numbers (
-            i2  INT2    NOT NULL,
-            i4  INT4    NOT NULL,
-            i8  INT8        NULL,
-            num numeric     NULL,
-            f4  float4  NOT NULL,
-            f8  float8      NULL,
-            b   bool    NOT NULL,
-            o   OID     NOT NULL,
-            o8  OID8    NOT NULL
+            i2  INT2           NOT NULL,
+            i4  INT4           NOT NULL,
+            i8  INT8               NULL,
+            num numeric            NULL,
+            np  numeric(32)        NULL,
+            nps numeric(12, 6)     NULL,
+            f4  float4         NOT NULL,
+            f8  float8             NULL,
+            b   bool           NOT NULL,
+            o   OID            NOT NULL,
+            o8  OID8           NOT NULL
         )
     });
     check_query(
@@ -41,20 +43,23 @@ NUMBERS: {
         qq{COPY numbers FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 UInt64" }],
+        qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal256(38) NULL, np Decimal(32,0) NULL, nps Decimal(12,6) NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 UInt64" }],
+        # qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal256(38) NULL, np Decimal(32,0) NULL, nps Decimal(12,6) NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 UInt64" }],
     );
 
     $node->safe_psql(postgres => q{
         CREATE TABLE number_arrays (
-            i2  INT2[]    NOT NULL,
-            i4  INT4[]    NOT NULL,
-            i8  INT8[]    NOT NULL,
-            num numeric[] NOT NULL,
-            f4  float4[]  NOT NULL,
-            f8  float8[]  NOT NULL,
-            b   bool[]    NOT NULL,
-            o   OID[]     NOT NULL,
-            o8  OID8[]    NOT NULL
+            i2  INT2[]           NOT NULL,
+            i4  INT4[]           NOT NULL,
+            i8  INT8[]           NOT NULL,
+            num numeric[]        NOT NULL,
+            np  numeric(32)[]    NOT NULL,
+            nps numeric(12, 6)[] NOT NULL,
+            f4  float4[]         NOT NULL,
+            f8  float8[]         NOT NULL,
+            b   bool[]           NOT NULL,
+            o   OID[]            NOT NULL,
+            o8  OID8[]           NOT NULL
         )
     });
     check_query(
@@ -62,7 +67,8 @@ NUMBERS: {
         qq{COPY number_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "i2 Array(Int16), i4 Array(Int32), i8 Array(Int64), num Array(Decimal), f4 Array(Float32), f8 Array(Float64), b Array(Bool), o Array(UInt32), o8 Array(UInt64)" }],
+        qr[\Q structure: "i2 String, i4 String, i8 String, num String, np String, nps String, f4 String, f8 String, b String, o String, o8 String" }],
+        # qr[\Q structure: "i2 Array(Int16), i4 Array(Int32), i8 Array(Int64), num Array(Decimal256(38)), np Array(Decimal(32,0)), nps Array(Decimal(12,6)), f4 Array(Float32), f8 Array(Float64), b Array(Bool), o Array(UInt32), o8 Array(UInt64)" }],
     );
 }
 
@@ -94,7 +100,8 @@ STRINGS: {
         qq{COPY string_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "t Array(String), ba Array(String), n Array(String)" }],
+        qr[\Q structure: "t String, ba String, n String" }],
+        # qr[\Q structure: "t Array(String), ba Array(String), n Array(String)" }],
     );
 }
 
@@ -112,7 +119,8 @@ FIXIES: {
         qq{COPY fixies FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "cr FixedString(6), ch FixedString(12), bp String, pbn FixedString(8)" }],
+        qr[\Q structure: "cr String(6), ch String(12), bp String, pbn String(8)" }],
+        # qr[\Q structure: "cr FixedString(6), ch FixedString(12), bp String, pbn FixedString(8)" }],
     );
 
     $node->safe_psql(postgres => q{
@@ -128,7 +136,8 @@ FIXIES: {
         qq{COPY fixie_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "cr Array(FixedString(6)), ch Array(FixedString(12)), bp Array(String), pbn Array(FixedString(8))" }],
+        qr[\Q structure: "cr String, ch String, bp String, pbn String" }],
+        # qr[\Q structure: "cr Array(FixedString(6)), ch Array(FixedString(12)), bp Array(String), pbn Array(FixedString(8))" }],
     );
 }
 
@@ -170,7 +179,8 @@ AS_STRINGS: {
         qq{COPY non_string_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "ival Array(String), tsv Array(String), tsq Array(String), jp Array(String), mon Array(String), xml Array(String), cir Array(String), na String" }],
+        qr[\Q structure: "ival String, tsv String, tsq String, jp String, mon String, xml String, cir String, na String" }],
+        # qr[\Q structure: "ival Array(String), tsv Array(String), tsq Array(String), jp Array(String), mon Array(String), xml Array(String), cir Array(String), na String" }],
     );
 }
 
@@ -204,7 +214,8 @@ VARCHAR: {
         qq{COPY varchar_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "vc Array(String), vcn Array(String(8)), bc Array(String), bcn Array(String(4))" }],
+        qr[\Q structure: "vc String, vcn String, bc String, bcn String" }],
+        # qr[\Q structure: "vc Array(String), vcn Array(String(8)), bc Array(String), bcn Array(String(4))" }],
     );
 }
 
@@ -221,7 +232,7 @@ JSON_UUID: {
         qq{COPY json_uuid FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "u UUID, j JSON, jb JSON NULL" }],
+        qr[\Q structure: "u UUID, j String, jb String NULL" }],
     );
 
     $node->safe_psql(postgres => q{
@@ -236,7 +247,8 @@ JSON_UUID: {
         qq{COPY json_uuid_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "u Array(UUID), j Array(JSON), jb Array(JSON)" }],
+        qr[\Q structure: "u String, j String, jb String" }],
+        # qr[\Q structure: "u Array(UUID), j Array(JSON), jb Array(JSON)" }],
     );
 }
 
@@ -257,7 +269,7 @@ GEO: {
         qq{COPY geos FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "p Point, line String, lseg LineString, box Polygon, path LineString, poly Polygon, cir String" }],
+        qr[\Q structure: "p Point, line String, lseg String, box String, path String, poly String, cir String" }],
     );
 
     $node->safe_psql(postgres => q{
@@ -276,7 +288,8 @@ GEO: {
         qq{COPY geo_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "p Array(Point), line Array(String), lseg Array(LineString), box Array(Polygon), path Array(LineString), poly Array(Polygon), cir Array(String)" }],
+        qr[\Q structure: "p String, line String, lseg String, box String, path String, poly String, cir String" }],
+        # qr[\Q structure: "p Array(Point), line Array(String), lseg Array(LineString), box Array(Polygon), path Array(LineString), poly Array(Polygon), cir Array(String)" }],
     );
 }
 
@@ -300,7 +313,7 @@ DATETIME: {
         qq{COPY datetime FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "ts String NULL, tsn String NULL, tstz DateTime64, tstzn DateTime64, date Date32, "time" Time64, timen Time64, ttz Time64, ttzn Time64, ival String" }],
+        qr[\Q structure: "ts String NULL, tsn String NULL, tstz DateTime64(6, 'UTC'), tstzn DateTime64(6, 'UTC'), date Date32, "time" Time64(6), timen Time64(6), ttz String, ttzn String, ival String" }],
     );
 
     $node->safe_psql(postgres => q{
@@ -322,7 +335,8 @@ DATETIME: {
         qq{COPY datetime_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "ts Array(String), tsn Array(String), tstz Array(DateTime64), tstzn Array(DateTime64), date Array(Date32), "time" Array(Time64), timen Array(Time64), ttz Array(Time64), ttzn Array(Time64), ival Array(String)" }],
+        qr[\Q structure: "ts String, tsn String, tstz String, tstzn String, date String, "time" String, timen String, ttz String, ttzn String, ival String" }],
+        # qr[\Q structure: "ts Array(String), tsn Array(String), tstz Array(DateTime64(6, 'UTC')), tstzn Array(DateTime64(6, 'UTC')), date Array(Date32), "time" Array(Time64(6)), timen Array(Time64(6)), ttz Array(Time64(6)), ttzn Array(Time64(6)), ival Array(String)" }],
     );
 }
 
@@ -359,7 +373,8 @@ ENUMS: {
         qq{COPY enum_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "mood Array(String), dow Array(String)" }],
+        qr[\Q structure: "mood String, dow String" }],
+        # qr[\Q structure: "mood Array(String), dow Array(String)" }],
     );
 }
 
@@ -393,7 +408,8 @@ NETS: {
         qq{COPY net_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "inet Array(String), cidr Array(String), mac Array(String), mac8 Array(String)" }],
+        qr[\Q structure: "inet String, cidr String, mac String, mac8 String" }],
+        # qr[\Q structure: "inet Array(String), cidr Array(String), mac Array(String), mac8 Array(String)" }],
     );
 }
 
@@ -403,7 +419,6 @@ BITS: {
             b  BIT       NOT NULL,
             bn BIT(3)    NOT NULL,
             vb varbit(6) NOT NULL
-
         )
     });
     check_query(
@@ -427,7 +442,8 @@ BITS: {
         qq{COPY bit_arrays FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "b Array(FixedString(1)), bn Array(FixedString(3)), vb Array(String(6))" }],
+        qr[\Q structure: "b String, bn String, vb String" }],
+        # qr[\Q structure: "b Array(FixedString(1)), bn Array(FixedString(3)), vb Array(String(6))" }],
     );
 }
 

--- a/test/expected/big-parquet.out
+++ b/test/expected/big-parquet.out
@@ -1,6 +1,4 @@
 LOAD 'chdb';
-SET datestyle = 'ISO';
-SET session timezone = 'UTC'; -- https://github.com/chdb-io/chdb-core/issues/143
 \getenv test_dir PG_ABS_SRCDIR
 \set parquet_file file:// :test_dir /big.tmp/big.parquet
 CREATE TYPE http_method AS ENUM(

--- a/test/expected/types.out
+++ b/test/expected/types.out
@@ -1,0 +1,618 @@
+LOAD 'chdb';
+SET session timezone = 'UTC';
+SET datestyle = 'ISO';
+\getenv test_dir PG_ABS_SRCDIR
+\set test_file :test_dir /types.tmp/types.tsv
+\set test_url file:// :test_file
+/****************************************************************************/
+-- Numbers.
+CREATE TABLE numbers (
+    i2  INT2           NOT NULL,
+    i4  INT4           NOT NULL,
+    i8  INT8               NULL,
+    num numeric            NULL,
+    np  numeric(32)        NULL,
+    nps numeric(12, 6)     NULL,
+    f4  float4         NOT NULL,
+    f8  float8             NULL,
+    b   bool           NOT NULL,
+    o   OID            NOT NULL,
+    o8  OID8           NOT NULL
+);
+INSERT INTO numbers
+VALUES (0, 0, 0, 0, 0, 0, 0, 0, false, 0, 0)
+     , (0, 0, NULL, NULL, NULL, NULL, 0, NULL, false, 0, 0)
+     , (-32768, -2147483648, -9223372036854775808, -987654321.123456789, -987654321, -123456.545675, -1.1, -98.68, false, 0, 0)
+     , (32767, 2147483647, 9223372036854775807, 987654321.123456789, 987654321, 123456.545675, 1.1, 98.68, true, 0, 0)
+    -- chDB doesn't support NaN or Infinity.
+    --  , (42, 42, 42, 'nan', 'nan', 'nan', 'nan', 'nan', true, 0, 0)
+    --  , (-42, -42, -42, '-infinity', 0, 0, '-infinity', '-infinity', true, 0, 0)
+    --  , (42, 42, 42, 'infinity', 0, 0, 'infinity', 'infinity', true, 0, 0)
+;
+COPY numbers TO :'test_url';
+CREATE TABLE numbers2 (LIKE numbers INCLUDING ALL);
+COPY numbers2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM numbers
+EXCEPT ALL
+SELECT * FROM numbers2;
+ i2 | i4 | i8 | num | np | nps | f4 | f8 | b | o | o8 
+----+----+----+-----+----+-----+----+----+---+---+----
+(0 rows)
+
+/****************************************************************************/
+-- Number Arrays.
+CREATE TABLE number_arrays (
+    i2  INT2[]           NOT NULL,
+    i4  INT4[]           NOT NULL,
+    i8  INT8[]           NOT NULL,
+    num numeric[]        NOT NULL,
+    np  numeric(32)[]    NOT NULL,
+    nps numeric(12, 6)[] NOT NULL,
+    f4  float4[]         NOT NULL,
+    f8  float8[]         NOT NULL,
+    b   bool[]           NOT NULL,
+    o   OID[]            NOT NULL,
+    o8  OID8[]           NOT NULL
+);
+INSERT INTO number_arrays
+VALUES ('{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{false}', '{0}', '{0}')
+     , ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')
+     , ('{-32768,32767}', '{-2147483648,2147483647}', '{-9223372036854775808,9223372036854775807}', '{-987654321.123456789,987654321.123456789}', '{-987654321,987654321}', '{-123456.545675,123456.545675}', '{-1.1,1.1}', '{-98.68,98.68}', '{false,true}', '{0, 0}', '{0,0}')
+     , ('{0, NULL}', '{NULL, 0}', '{NULL}', '{0, NULL}', '{NULL, 0}', '{NULL}', '{0,NULL}', '{NULL,0}', '{false,NULL}', '{NULL}', '{0,NULL}')
+;
+COPY number_arrays TO :'test_url';
+CREATE TABLE number_arrays2 (LIKE number_arrays INCLUDING ALL);
+COPY number_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM number_arrays
+EXCEPT ALL
+SELECT * FROM number_arrays2;
+ i2 | i4 | i8 | num | np | nps | f4 | f8 | b | o | o8 
+----+----+----+-----+----+-----+----+----+---+---+----
+(0 rows)
+
+/****************************************************************************/
+-- Strings.
+CREATE TABLE strings (
+    t  TEXT    NOT NULL,
+    ba BYTEA   NOT NULL,
+    n  NAME        NULL
+);
+INSERT INTO strings
+VALUES ('', '', '')
+     , ('  ', '   ', NULL)
+     , ('hi', '\xdeadbeef', 'yo')
+     , ('😃 🐨 🎱', '\x83c2815f9018eb2d4c26dac9d69c4c93ddc7a284', 'big fat name')
+     , ('"Bøwie"', '\x9a60f295bcb186a729d04e76377b7f122b2a1dd9', '"ALL CAPS"')
+;
+COPY strings TO :'test_url';
+CREATE TABLE strings2 (LIKE strings INCLUDING ALL);
+COPY strings2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM strings
+EXCEPT ALL
+SELECT * FROM strings2;
+ t | ba | n 
+---+----+---
+(0 rows)
+
+/****************************************************************************/
+-- String Arrays.
+CREATE TABLE string_arrays (
+    t  TEXT[]    NOT NULL,
+    ba BYTEA[]   NOT NULL,
+    n  NAME[]    NOT NULL
+);
+INSERT INTO string_arrays
+VALUES ('{}', '{}', '{}')
+     , ('{hi}', '{\xdeadbeef}', '{yo}')
+     , ('{hi, NULL}', '{NULL, \xdeadbeef}', '{NULL}')
+     , ('{😃 🐨 🎱,"\"GO\""}', '{\xdeadbeef, \x83c2815f9018eb2d4c26dac9d69c4c93ddc7a284}', '{big fat name,NULL}')
+;
+COPY string_arrays TO :'test_url';
+CREATE TABLE string_arrays2 (LIKE string_arrays INCLUDING ALL);
+COPY string_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM string_arrays
+EXCEPT ALL
+SELECT * FROM string_arrays2;
+ t | ba | n 
+---+----+---
+(0 rows)
+
+/****************************************************************************/
+-- Fixed-length strings.
+CREATE TABLE fixies (
+    cr  character(6) NOT NULL,
+    ch  char(12)     NOT NULL,
+    bp  bpchar       NOT NULL,
+    pbn bpchar(8)        NULL
+);
+INSERT INTO fixies
+VALUES ('      ', '            ', ' ', '        ')
+     , ('', '', '', NULL)
+     , ('hi  ', 'hi   ', '', NULL)
+     , ('😃 🐨 🎱', '是无效的命令', '否', '未定义的参数')
+;
+COPY fixies TO :'test_url';
+CREATE TABLE fixies2 (LIKE fixies INCLUDING ALL);
+COPY fixies2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM fixies
+EXCEPT ALL
+SELECT * FROM fixies2;
+ cr | ch | bp | pbn 
+----+----+----+-----
+(0 rows)
+
+/****************************************************************************/
+-- Fixed-length string Arrays.
+CREATE TABLE fixie_arrays (
+    cr  character(6)[] NOT NULL,
+    ch  char(12)[]     NOT NULL,
+    bp  bpchar[]       NOT NULL,
+    pbn bpchar(8)[]    NOT NULL
+);
+INSERT INTO fixie_arrays
+VALUES ('{"      "}', '{"            "}', '{" "}', '{"        "}')
+     , ('{""}', '{""}', '{""}', '{""}')
+     , ('{😃 🐨 🎱, NULL}', '{NULL, 是无效的命令}', '{NULL}', '{未定义的参数, NULL}')
+     , ('{"Bøwie", "\"GO\""}', '{否,模板}', '{x,y,z,NULL}', '{"ALL CAPS"}')
+;
+COPY fixie_arrays TO STDOUT;
+{"      "}	{"            "}	{" "}	{"        "}
+{"      "}	{"            "}	{""}	{"        "}
+{"😃 🐨 🎱 ",NULL}	{NULL,"是无效的命令      "}	{NULL}	{"未定义的参数  ",NULL}
+{"Bøwie ","\\"GO\\"  "}	{"否           ","模板          "}	{x,y,z,NULL}	{"ALL CAPS"}
+COPY fixie_arrays TO :'test_url';
+CREATE TABLE fixie_arrays2 (LIKE fixie_arrays INCLUDING ALL);
+COPY fixie_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM fixie_arrays
+EXCEPT ALL
+SELECT * FROM fixie_arrays2;
+ cr | ch | bp | pbn 
+----+----+----+-----
+(0 rows)
+
+/****************************************************************************/
+-- Other things as strings.
+CREATE TABLE non_strings (
+    ival INTERVAL NOT NULL,
+    tsv  tsvector NOT NULL,
+    tsq  tsquery  NOT NULL,
+    jp   jsonpath NOT NULL,
+    mon  money    NOT NULL,
+    xml  XML      NOT NULL,
+    cir  circle   NOT NULL
+);
+INSERT INTO non_strings
+VALUES ('02:00:00', 'a fat cat', 'fat & rat', '$.x', '100', '<html>hi</html>', '<(500,500),500>')
+     , ('0', '', 'x', '$', '0', '', '0,0,1')
+     , ('10d', 'winter party', 'fat:AB & cat', '$.x.y[2]', '-20', '<?xml version="1.0" encoding="UTF-8"?>', '(0,0),1')
+;
+COPY non_strings TO :'test_url';
+CREATE TABLE non_strings2 (LIKE non_strings INCLUDING ALL);
+COPY non_strings2 FROM :'test_url';
+-- They should be the same, first comparable values:
+SELECT ival, tsv, tsq, mon FROM non_strings
+EXCEPT ALL
+SELECT ival, tsv, tsq, mon FROM non_strings2;
+ ival | tsv | tsq | mon 
+------+-----+-----+-----
+(0 rows)
+
+-- Cast non-comparable values to text to compare.
+SELECT jp::text, xml::text, cir::text FROM non_strings
+EXCEPT ALL
+SELECT jp::text, xml::text, cir::text FROM non_strings2;
+      jp      |                  xml                   |    cir    
+--------------+----------------------------------------+-----------
+ $."x"."y"[2] | <?xml version="1.0" encoding="UTF-8"?> | <(0,0),1>
+(1 row)
+
+/****************************************************************************/
+-- Other arrays of things.
+CREATE TABLE non_string_arrays (
+    ival INTERVAL[] NOT NULL,
+    tsv  tsvector[] NOT NULL,
+    tsq  tsquery[]  NOT NULL,
+    jp   jsonpath[] NOT NULL,
+    mon  money[]    NOT NULL,
+    xml  XML[]      NOT NULL,
+    cir  circle[]   NOT NULL
+);
+INSERT INTO non_string_arrays
+VALUES ('{02:00:00}', '{a fat cat}', '{fat & rat}', '{$.x}', '{100}', '{<html>hi</html>}', '{"<(500,500),500>"}')
+     , ('{0}', '{}', '{x}', '{$}', '{0}', '{}', '{"0,0,1"}')
+     , ('{0}', '{}', '{x}', '{$}', '{0}', '{}', '{"0,0,1"}')
+     , ('{0, NULL}', '{NULL}', '{NULL, x}', '{$, NULL}', '{NULL, 0}', '{NULL}', '{"0,0,1", NULL}')
+     , ('{10d, 5s}', '{fat cat, ❄️ party}', '{fat:AB & cat, ❄️}', '{$.x.💿[2], $}', '{-20}', '{"<a id=\"🦁\"/>", ""}', '{"(0,0),1", "<(500,500),500>"}')
+;
+COPY non_string_arrays TO :'test_url';
+CREATE TABLE non_string_arrays2 (LIKE non_string_arrays INCLUDING ALL);
+COPY non_string_arrays2 FROM :'test_url';
+-- They should be the same, first comparable values:
+SELECT ival, tsv, tsq, mon FROM non_string_arrays
+EXCEPT ALL
+SELECT ival, tsv, tsq, mon FROM non_string_arrays2;
+ ival | tsv | tsq | mon 
+------+-----+-----+-----
+(0 rows)
+
+-- Cast non-comparable values to text to compare.
+SELECT jp::text[], xml::text[], cir::text[] FROM non_string_arrays
+EXCEPT ALL
+SELECT jp::text[], xml::text[], cir::text[] FROM non_string_arrays2;
+ jp | xml | cir 
+----+-----+-----
+(0 rows)
+
+/****************************************************************************/
+-- Variable length strings.
+CREATE TABLE varchars (
+    vc  VARCHAR    NOT NULL,
+    vcn VARCHAR(8) NOT NULL,
+    bc  VARBIT     NOT NULL,
+    bcn VARBIT(4)  NOT NULL
+);
+INSERT INTO varchars
+VALUES ('', '', '', '')
+     , ('   ', '        ', '10100101', '1010')
+     , ('hi there', 'hi you', '0', '0101')
+     , ('😃 🐨 🎱', '是无效的命令', '1', '1100')
+;
+COPY varchars TO :'test_url';
+CREATE TABLE varchars2 (LIKE varchars INCLUDING ALL);
+COPY varchars2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM varchars
+EXCEPT ALL
+SELECT * FROM varchars2;
+ vc | vcn | bc | bcn 
+----+-----+----+-----
+(0 rows)
+
+/****************************************************************************/
+-- Variable length string arrays.
+CREATE TABLE varchar_arrays (
+    vc  VARCHAR[]    NOT NULL,
+    vcn VARCHAR(8)[] NOT NULL,
+    bc  VARBIT[]     NOT NULL,
+    bcn VARBIT(4)[]  NOT NULL
+);
+INSERT INTO varchar_arrays
+VALUES ('{}', '{}', '{}', '{}')
+     , ('{   }', '{        }', '{10100101}', '{1010}')
+     , ('{hi there, NULL}', '{NULL, hi you}', '{NULL, 0, 1}', '{0101, 0011}')
+     , ('{😃 🐨 🎱}', '{是无效的命令}', '{1, NULL}', '{1100}')
+;
+COPY varchar_arrays TO :'test_url';
+CREATE TABLE varchar_arrays2 (LIKE varchar_arrays INCLUDING ALL);
+COPY varchar_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM varchar_arrays
+EXCEPT ALL
+SELECT * FROM varchar_arrays2;
+ vc | vcn | bc | bcn 
+----+-----+----+-----
+(0 rows)
+
+/****************************************************************************/
+-- JSON & UUID values.
+CREATE TABLE json_uuid (
+    u  UUID   NOT NULL,
+    j  JSON   NOT NULL,
+    jb JSONB      NULL
+);
+INSERT INTO json_uuid
+VALUES ('00000000-0000-0000-0000-000000000000', 'null', 'null')
+     , ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', '{"x": true}', '{"y": false}')
+     , ('B82601F4-2FF0-4F05-99E4-2CAAC200BA0F', '42', '42')
+     , ('A411B3DC-76c7-4D5D-92B2-3ab802504f1f', '98.6', '98.6')
+     , ('8e6568ce-0cd0-43f0-9118-b2b1171b7a5b', 'true', 'true')
+     , ('CE7F909D-12F6-455E-8C44-80BECE3D5912', '[1, "🖲️", null]', '[1, "🖲️", null]')
+;
+COPY json_uuid TO :'test_url';
+CREATE TABLE json_uuid2 (LIKE json_uuid INCLUDING ALL);
+COPY json_uuid2 FROM :'test_url';
+-- They should be the same
+SELECT u FROM json_uuid
+EXCEPT ALL
+SELECT u FROM json_uuid2;
+ u 
+---
+(0 rows)
+
+SELECT j::text, jb::text FROM json_uuid
+EXCEPT ALL
+SELECT j::text, jb::text FROM json_uuid2;
+ j | jb 
+---+----
+(0 rows)
+
+/****************************************************************************/
+-- JSON & UUID arrays.
+CREATE TABLE json_uuid_arrays (
+    u  UUID[]   NOT NULL,
+    j  JSON[]   NOT NULL,
+    jb JSONB[]      NULL
+);
+INSERT INTO json_uuid_arrays
+VALUES ('{00000000-0000-0000-0000-000000000000}', '{null}', '{null}')
+     , ('{}', '{}', '{}')
+     , ('{6ba7b810-9dad-11d1-80b4-00c04fd430c8, NULL}', '{NULL, "{\"x\": true}"}', '{"{\"y\": false}", NULL}')
+     , ('{B82601F4-2FF0-4F05-99E4-2CAAC200BA0F, A411B3DC-76c7-4D5D-92B2-3ab802504f1f}', '{42, 98.6, []}', '{42, 98.6, []}')
+     , ('{NULL}', '{"[1, \"🖲️\", null]"}', '{"[1, \"🖲️\", null]"}')
+;
+COPY json_uuid_arrays TO :'test_url';
+CREATE TABLE json_uuid_arrays2 (LIKE json_uuid_arrays INCLUDING ALL);
+COPY json_uuid_arrays2 FROM :'test_url';
+-- They should be the same, first comparable values:
+SELECT u FROM json_uuid_arrays
+EXCEPT ALL
+SELECT u FROM json_uuid_arrays2;
+ u 
+---
+(0 rows)
+
+-- Cast non-comparable values to text to compare.
+SELECT j::text, jb::text FROM json_uuid_arrays
+EXCEPT ALL
+SELECT j::text, jb::text FROM json_uuid_arrays2;
+ j | jb 
+---+----
+(0 rows)
+
+/****************************************************************************/
+-- Geometric types.
+CREATE TABLE geos (
+    p   point    NOT NULL,
+    line line    NOT NULL,
+    lseg lseg    NOT NULL,
+    box  box     NOT NULL,
+    path path    NOT NULL,
+    poly polygon NOT NULL,
+    cir  circle  NOT NULL
+);
+INSERT INTO geos
+VALUES ('0,0', '(1,1),(2,2)', '((11,11),(12,12))', '((11,11),(13,13))', '((11,12),(13,13),(14,14))', '((11,12),(13,13),(14,14))', '1,1,1')
+     , ('(11,nan)', '{nan, 1, nan}', '((11,nan),(nan,12))', '((nan,11),(13,13))', '((11,nan),(13,13),(14,14))', '((11,12),(13,13),(14,nan))', '<(500,500),500>')
+     , ('(11,nan)', '{nan, 1, nan}', '((11,nan),(nan,12))', '((nan,11),(13,13))', '[(11,12),(13,13),(14,14)]', '((11,12),(13,13),(14,nan))', '(0,0),1')
+;
+COPY geos TO :'test_url';
+CREATE TABLE geos2 (LIKE geos INCLUDING ALL);
+COPY geos2 FROM :'test_url';
+-- They should be the same
+SELECT p::text, line::text, lseg::text, box::text, path::text, poly::text, cir::text FROM geos
+EXCEPT ALL
+SELECT p::text, line::text, lseg::text, box::text, path::text, poly::text, cir::text FROM geos;
+ p | line | lseg | box | path | poly | cir 
+---+------+------+-----+------+------+-----
+(0 rows)
+
+/****************************************************************************/
+-- Geometric type arrays.
+CREATE TABLE geo_arrays (
+    p   point[]    NOT NULL,
+    line line[]    NOT NULL,
+    lseg lseg[]    NOT NULL,
+    box  box[]     NOT NULL,
+    path path[]    NOT NULL,
+    poly polygon[] NOT NULL,
+    cir  circle[]  NOT NULL
+);
+-- Postgres box arrays use ; as a delimiter.
+INSERT INTO geo_arrays
+VALUES ('{"0,0"}', '{"(1,1),(2,2)"}', '{"((11,11),(12,12))"}', '{"((11,11),(13,13))"}', '{"((11,12),(13,13),(14,14))"}', '{"((11,12),(13,13),(14,14))"}', '{"1,1,1"}')
+     , ('{"(11,nan)", NULL}', '{NULL, "{nan, 1, nan}"}', '{NULL}', '{"((nan,11),(13,13))"; NULL}', '{NULL, "((11,nan),(13,13),(14,14))"}', '{"((11,12),(13,13),(14,nan))", NULL}', '{NULL}')
+;
+COPY geo_arrays TO :'test_url';
+CREATE TABLE geo_arrays2 (LIKE geo_arrays INCLUDING ALL);
+COPY geo_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT p::text[], line::text[], lseg::text[], box::text[], path::text[], poly::text[], cir::text[] FROM geo_arrays
+EXCEPT ALL
+SELECT p::text[], line::text[], lseg::text[], box::text[], path::text[], poly::text[], cir::text[] FROM geo_arrays;
+ p | line | lseg | box | path | poly | cir 
+---+------+------+-----+------+------+-----
+(0 rows)
+
+/****************************************************************************/
+-- Dates and times.
+CREATE TABLE datetimes (
+    ts    TIMESTAMP          NULL,
+    tsn   TIMESTAMP(3)       NULL,
+    tstz  TIMESTAMPTZ    NOT NULL,
+    tstzn TIMESTAMPTZ(4) NOT NULL,
+    date  DATE           NOT NULL,
+    time  TIME           NOT NULL,
+    timen TIME(3)        NOT NULL,
+    ttz   TIMETZ         NOT NULL,
+    ttzn  TIMETZ(2)      NOT NULL,
+    ival  INTERVAL       NOT NULL
+);
+INSERT INTO datetimes
+VALUES ('2026-07-23 20:43:10.836612', '2026-07-23 20:43:27.363', '2026-07-23 20:43:50.944042+00', '2026-07-23 13:44:46.8445-07', '2026-07-23', '13:45:15.416013', '13:45:24.282', '13:45:35.306886-07', '13:45:49.17-07', '1 day')
+     , (NULL, NULL, '2299-12-31 23:59:59.999999Z', '1900-01-01 00:00:00Z', '1900-01-01', '00:00:00', '24:00:00', '00:00:00+1559', '24:00:00-1559', '-178000000 years')
+;
+COPY datetimes TO :'test_url';
+CREATE TABLE datetimes2 (LIKE datetimes INCLUDING ALL);
+COPY datetimes2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM datetimes
+EXCEPT ALL
+SELECT * FROM datetimes2;
+ ts | tsn | tstz | tstzn | date | time | timen | ttz | ttzn | ival 
+----+-----+------+-------+------+------+-------+-----+------+------
+(0 rows)
+
+/****************************************************************************/
+-- Dates and time arrays.
+CREATE TABLE datetime_arrays (
+    ts    TIMESTAMP[]      NOT NULL,
+    tsn   TIMESTAMP(3)[]   NOT NULL,
+    tstz  TIMESTAMPTZ[]    NOT NULL,
+    tstzn TIMESTAMPTZ(4)[] NOT NULL,
+    date  DATE[]           NOT NULL,
+    time  TIME[]           NOT NULL,
+    timen TIME(3)[]        NOT NULL,
+    ttz   TIMETZ[]         NOT NULL,
+    ttzn  TIMETZ(2)[]      NOT NULL,
+    ival  INTERVAL[]       NOT NULL
+);
+INSERT INTO datetime_arrays
+VALUES ('{2026-07-23 20:43:10.836612}', '{2026-07-23 20:43:27.363}', '{2026-07-23 20:43:50.944042+00}', '{2026-07-23 13:44:46.8445-07}', '{2026-07-23}', '{13:45:15.416013}', '{13:45:24.282}', '{13:45:35.306886-07}', '{13:45:49.17-07}', '{1 day}')
+     , ('{1900-01-01 00:00:00, 2299-12-31 23:59:59.999999}', '{}', '{1900-01-01 00:00:00Z, 2299-12-31 23:59:59.999999Z}', '{NULL}', '{1900-01-01, 2299-12-31}', '{00:00:00, 24:00:00}', '{NULL}', '{00:00:00+1559, 24:00:00-1559}', '{09:23:23Z}', '{-178000000 years, NULL}')
+;
+COPY datetime_arrays TO :'test_url';
+CREATE TABLE datetime_arrays2 (LIKE datetime_arrays INCLUDING ALL);
+COPY datetime_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM datetime_arrays
+EXCEPT ALL
+SELECT * FROM datetime_arrays2;
+ ts | tsn | tstz | tstzn | date | time | timen | ttz | ttzn | ival 
+----+-----+------+-------+------+------+-------+-----+------+------
+(0 rows)
+
+/****************************************************************************/
+-- Enums.
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+CREATE TYPE dow AS ENUM ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat');
+CREATE TABLE enums (
+    dow  dow  NOT NULL,
+    mood mood NOT NULL
+);
+INSERT INTO enums
+VALUES ('Sun', 'ok')
+     , ('Mon', 'sad')
+     , ('Fri', 'happy')
+;
+COPY enums TO :'test_url';
+CREATE TABLE enums2 (LIKE enums INCLUDING ALL);
+COPY enums2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM enums
+EXCEPT ALL
+SELECT * FROM enums2;
+ dow | mood 
+-----+------
+(0 rows)
+
+/****************************************************************************/
+-- Enum Arrays.
+CREATE TABLE enum_arrays (
+    dow  dow[]  NOT NULL,
+    mood mood[] NOT NULL
+);
+INSERT INTO enum_arrays
+VALUES ('{Sun, NULL, Thu}', '{ok, NULL, ok}')
+     , ('{Mon, Tue, Wed}', '{sad, NULL, happy}')
+;
+COPY enum_arrays TO :'test_url';
+CREATE TABLE enum_arrays2 (LIKE enum_arrays INCLUDING ALL);
+COPY enum_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM enum_arrays
+EXCEPT ALL
+SELECT * FROM enum_arrays2;
+ dow | mood 
+-----+------
+(0 rows)
+
+/****************************************************************************/
+-- Network Addresses.
+CREATE TABLE nets (
+    inet INET     NOT NULL,
+    cidr CIDR     NOT NULL,
+    mac  MACADDR  NOT NULL,
+    mac8 MACADDR8 NOT NULL
+);
+INSERT INTO nets
+VALUES ('1.2.6.4/16', '121.111.63.82', '22:00:5c:08:55:08', '08:00:2b:01:02:03:04:05')
+     , ('89.225.196.191', '192.168.1.0/24', '08:00:2b:01:02:03', '22:00:5c:08:55:08:01:02')
+     , ('::4:3:2:0/24', '1.2.6.4', '01:02:03:04:05:06', '00:01:03:86:1c:ba')
+;
+COPY nets TO :'test_url';
+CREATE TABLE nets2 (LIKE nets INCLUDING ALL);
+COPY nets2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM nets
+EXCEPT ALL
+SELECT * FROM nets2;
+ inet | cidr | mac | mac8 
+------+------+-----+------
+(0 rows)
+
+/****************************************************************************/
+-- Network Address Arrays.
+CREATE TABLE net_arrays (
+    inet INET[]     NOT NULL,
+    cidr CIDR[]     NOT NULL,
+    mac  MACADDR[]  NOT NULL,
+    mac8 MACADDR8[] NOT NULL
+);
+INSERT INTO net_arrays
+VALUES ('{1.2.6.4/16}', '{121.111.63.82}', '{22:00:5c:08:55:08}', '{08:00:2b:01:02:03:04:05}')
+     , ('{89.225.196.191, NULL}', '{NULL}', '{NULL, 08:00:2b:01:02:03}', '{22:00:5c:08:55:08:01:02}')
+     , ('{::4:3:2:0/24, 126::1}', '{1.2.6.4, 126::1}', '{01:02:03:04:05:06, 02:03:04:05:06:07}', '{00:01:03:86:1c:ba, 08002b-010203}')
+;
+COPY net_arrays TO :'test_url';
+CREATE TABLE net_arrays2 (LIKE net_arrays INCLUDING ALL);
+COPY net_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM net_arrays
+EXCEPT ALL
+SELECT * FROM net_arrays2;
+ inet | cidr | mac | mac8 
+------+------+-----+------
+(0 rows)
+
+\! rm -rf test/types.tmp
+/****************************************************************************/
+-- Bit Strings.
+CREATE TABLE bits (
+    b  BIT       NOT NULL,
+    bn BIT(3)    NOT NULL,
+    vb varbit(6) NOT NULL
+);
+INSERT INTO bits
+VALUES ('1', '111', '111111')
+     , ('0', '000', '000000')
+     , ('0', '000', '000000')
+;
+COPY bits TO :'test_url';
+CREATE TABLE bits2 (LIKE bits INCLUDING ALL);
+COPY bits2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM bits
+EXCEPT ALL
+SELECT * FROM bits2;
+ b | bn | vb 
+---+----+----
+(0 rows)
+
+/****************************************************************************/
+-- Bit String Arrays
+CREATE TABLE bit_arrays (
+    b  BIT[]       NOT NULL,
+    bn BIT(3)[]    NOT NULL,
+    vb varbit(6)[] NOT NULL
+);
+INSERT INTO bit_arrays
+VALUES ('{1}', '{111}', '{111111}')
+     , ('{0,1,NULL}', '{000,001,111,110}', '{000000,111001,101010}')
+;
+COPY bit_arrays TO :'test_url';
+CREATE TABLE bit_arrays2 (LIKE bit_arrays INCLUDING ALL);
+COPY bit_arrays2 FROM :'test_url';
+-- They should be the same
+SELECT * FROM bit_arrays
+EXCEPT ALL
+SELECT * FROM bit_arrays2;
+ b | bn | vb 
+---+----+----
+(0 rows)
+

--- a/test/sql/big-parquet.sql
+++ b/test/sql/big-parquet.sql
@@ -1,6 +1,4 @@
 LOAD 'chdb';
-SET datestyle = 'ISO';
-SET session timezone = 'UTC'; -- https://github.com/chdb-io/chdb-core/issues/143
 
 \getenv test_dir PG_ABS_SRCDIR
 \set parquet_file file:// :test_dir /big.tmp/big.parquet

--- a/test/sql/types.sql
+++ b/test/sql/types.sql
@@ -1,0 +1,603 @@
+LOAD 'chdb';
+SET session timezone = 'UTC';
+SET datestyle = 'ISO';
+
+\getenv test_dir PG_ABS_SRCDIR
+\set test_file :test_dir /types.tmp/types.tsv
+\set test_url file:// :test_file
+
+/****************************************************************************/
+-- Numbers.
+CREATE TABLE numbers (
+    i2  INT2           NOT NULL,
+    i4  INT4           NOT NULL,
+    i8  INT8               NULL,
+    num numeric            NULL,
+    np  numeric(32)        NULL,
+    nps numeric(12, 6)     NULL,
+    f4  float4         NOT NULL,
+    f8  float8             NULL,
+    b   bool           NOT NULL,
+    o   OID            NOT NULL,
+    o8  OID8           NOT NULL
+);
+
+INSERT INTO numbers
+VALUES (0, 0, 0, 0, 0, 0, 0, 0, false, 0, 0)
+     , (0, 0, NULL, NULL, NULL, NULL, 0, NULL, false, 0, 0)
+     , (-32768, -2147483648, -9223372036854775808, -987654321.123456789, -987654321, -123456.545675, -1.1, -98.68, false, 0, 0)
+     , (32767, 2147483647, 9223372036854775807, 987654321.123456789, 987654321, 123456.545675, 1.1, 98.68, true, 0, 0)
+    -- chDB doesn't support NaN or Infinity.
+    --  , (42, 42, 42, 'nan', 'nan', 'nan', 'nan', 'nan', true, 0, 0)
+    --  , (-42, -42, -42, '-infinity', 0, 0, '-infinity', '-infinity', true, 0, 0)
+    --  , (42, 42, 42, 'infinity', 0, 0, 'infinity', 'infinity', true, 0, 0)
+;
+
+COPY numbers TO :'test_url';
+CREATE TABLE numbers2 (LIKE numbers INCLUDING ALL);
+COPY numbers2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM numbers
+EXCEPT ALL
+SELECT * FROM numbers2;
+
+/****************************************************************************/
+-- Number Arrays.
+CREATE TABLE number_arrays (
+    i2  INT2[]           NOT NULL,
+    i4  INT4[]           NOT NULL,
+    i8  INT8[]           NOT NULL,
+    num numeric[]        NOT NULL,
+    np  numeric(32)[]    NOT NULL,
+    nps numeric(12, 6)[] NOT NULL,
+    f4  float4[]         NOT NULL,
+    f8  float8[]         NOT NULL,
+    b   bool[]           NOT NULL,
+    o   OID[]            NOT NULL,
+    o8  OID8[]           NOT NULL
+);
+
+INSERT INTO number_arrays
+VALUES ('{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{false}', '{0}', '{0}')
+     , ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')
+     , ('{-32768,32767}', '{-2147483648,2147483647}', '{-9223372036854775808,9223372036854775807}', '{-987654321.123456789,987654321.123456789}', '{-987654321,987654321}', '{-123456.545675,123456.545675}', '{-1.1,1.1}', '{-98.68,98.68}', '{false,true}', '{0, 0}', '{0,0}')
+     , ('{0, NULL}', '{NULL, 0}', '{NULL}', '{0, NULL}', '{NULL, 0}', '{NULL}', '{0,NULL}', '{NULL,0}', '{false,NULL}', '{NULL}', '{0,NULL}')
+;
+
+COPY number_arrays TO :'test_url';
+CREATE TABLE number_arrays2 (LIKE number_arrays INCLUDING ALL);
+COPY number_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM number_arrays
+EXCEPT ALL
+SELECT * FROM number_arrays2;
+
+/****************************************************************************/
+-- Strings.
+CREATE TABLE strings (
+    t  TEXT    NOT NULL,
+    ba BYTEA   NOT NULL,
+    n  NAME        NULL
+);
+
+INSERT INTO strings
+VALUES ('', '', '')
+     , ('  ', '   ', NULL)
+     , ('hi', '\xdeadbeef', 'yo')
+     , ('😃 🐨 🎱', '\x83c2815f9018eb2d4c26dac9d69c4c93ddc7a284', 'big fat name')
+     , ('"Bøwie"', '\x9a60f295bcb186a729d04e76377b7f122b2a1dd9', '"ALL CAPS"')
+;
+
+COPY strings TO :'test_url';
+CREATE TABLE strings2 (LIKE strings INCLUDING ALL);
+COPY strings2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM strings
+EXCEPT ALL
+SELECT * FROM strings2;
+
+/****************************************************************************/
+-- String Arrays.
+CREATE TABLE string_arrays (
+    t  TEXT[]    NOT NULL,
+    ba BYTEA[]   NOT NULL,
+    n  NAME[]    NOT NULL
+);
+
+INSERT INTO string_arrays
+VALUES ('{}', '{}', '{}')
+     , ('{hi}', '{\xdeadbeef}', '{yo}')
+     , ('{hi, NULL}', '{NULL, \xdeadbeef}', '{NULL}')
+     , ('{😃 🐨 🎱,"\"GO\""}', '{\xdeadbeef, \x83c2815f9018eb2d4c26dac9d69c4c93ddc7a284}', '{big fat name,NULL}')
+;
+
+COPY string_arrays TO :'test_url';
+CREATE TABLE string_arrays2 (LIKE string_arrays INCLUDING ALL);
+COPY string_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM string_arrays
+EXCEPT ALL
+SELECT * FROM string_arrays2;
+
+/****************************************************************************/
+-- Fixed-length strings.
+CREATE TABLE fixies (
+    cr  character(6) NOT NULL,
+    ch  char(12)     NOT NULL,
+    bp  bpchar       NOT NULL,
+    pbn bpchar(8)        NULL
+);
+
+INSERT INTO fixies
+VALUES ('      ', '            ', ' ', '        ')
+     , ('', '', '', NULL)
+     , ('hi  ', 'hi   ', '', NULL)
+     , ('😃 🐨 🎱', '是无效的命令', '否', '未定义的参数')
+;
+
+COPY fixies TO :'test_url';
+CREATE TABLE fixies2 (LIKE fixies INCLUDING ALL);
+COPY fixies2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM fixies
+EXCEPT ALL
+SELECT * FROM fixies2;
+
+/****************************************************************************/
+-- Fixed-length string Arrays.
+CREATE TABLE fixie_arrays (
+    cr  character(6)[] NOT NULL,
+    ch  char(12)[]     NOT NULL,
+    bp  bpchar[]       NOT NULL,
+    pbn bpchar(8)[]    NOT NULL
+);
+
+INSERT INTO fixie_arrays
+VALUES ('{"      "}', '{"            "}', '{" "}', '{"        "}')
+     , ('{""}', '{""}', '{""}', '{""}')
+     , ('{😃 🐨 🎱, NULL}', '{NULL, 是无效的命令}', '{NULL}', '{未定义的参数, NULL}')
+     , ('{"Bøwie", "\"GO\""}', '{否,模板}', '{x,y,z,NULL}', '{"ALL CAPS"}')
+;
+
+COPY fixie_arrays TO STDOUT;
+
+COPY fixie_arrays TO :'test_url';
+CREATE TABLE fixie_arrays2 (LIKE fixie_arrays INCLUDING ALL);
+COPY fixie_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM fixie_arrays
+EXCEPT ALL
+SELECT * FROM fixie_arrays2;
+
+/****************************************************************************/
+-- Other things as strings.
+CREATE TABLE non_strings (
+    ival INTERVAL NOT NULL,
+    tsv  tsvector NOT NULL,
+    tsq  tsquery  NOT NULL,
+    jp   jsonpath NOT NULL,
+    mon  money    NOT NULL,
+    xml  XML      NOT NULL,
+    cir  circle   NOT NULL
+);
+
+INSERT INTO non_strings
+VALUES ('02:00:00', 'a fat cat', 'fat & rat', '$.x', '100', '<html>hi</html>', '<(500,500),500>')
+     , ('0', '', 'x', '$', '0', '', '0,0,1')
+     , ('10d', 'winter party', 'fat:AB & cat', '$.x.y[2]', '-20', '<?xml version="1.0" encoding="UTF-8"?>', '(0,0),1')
+;
+
+COPY non_strings TO :'test_url';
+CREATE TABLE non_strings2 (LIKE non_strings INCLUDING ALL);
+COPY non_strings2 FROM :'test_url';
+
+-- They should be the same, first comparable values:
+SELECT ival, tsv, tsq, mon FROM non_strings
+EXCEPT ALL
+SELECT ival, tsv, tsq, mon FROM non_strings2;
+
+-- Cast non-comparable values to text to compare.
+SELECT jp::text, xml::text, cir::text FROM non_strings
+EXCEPT ALL
+SELECT jp::text, xml::text, cir::text FROM non_strings2;
+
+/****************************************************************************/
+-- Other arrays of things.
+CREATE TABLE non_string_arrays (
+    ival INTERVAL[] NOT NULL,
+    tsv  tsvector[] NOT NULL,
+    tsq  tsquery[]  NOT NULL,
+    jp   jsonpath[] NOT NULL,
+    mon  money[]    NOT NULL,
+    xml  XML[]      NOT NULL,
+    cir  circle[]   NOT NULL
+);
+
+INSERT INTO non_string_arrays
+VALUES ('{02:00:00}', '{a fat cat}', '{fat & rat}', '{$.x}', '{100}', '{<html>hi</html>}', '{"<(500,500),500>"}')
+     , ('{0}', '{}', '{x}', '{$}', '{0}', '{}', '{"0,0,1"}')
+     , ('{0}', '{}', '{x}', '{$}', '{0}', '{}', '{"0,0,1"}')
+     , ('{0, NULL}', '{NULL}', '{NULL, x}', '{$, NULL}', '{NULL, 0}', '{NULL}', '{"0,0,1", NULL}')
+     , ('{10d, 5s}', '{fat cat, ❄️ party}', '{fat:AB & cat, ❄️}', '{$.x.💿[2], $}', '{-20}', '{"<a id=\"🦁\"/>", ""}', '{"(0,0),1", "<(500,500),500>"}')
+;
+
+COPY non_string_arrays TO :'test_url';
+CREATE TABLE non_string_arrays2 (LIKE non_string_arrays INCLUDING ALL);
+COPY non_string_arrays2 FROM :'test_url';
+
+-- They should be the same, first comparable values:
+SELECT ival, tsv, tsq, mon FROM non_string_arrays
+EXCEPT ALL
+SELECT ival, tsv, tsq, mon FROM non_string_arrays2;
+
+-- Cast non-comparable values to text to compare.
+SELECT jp::text[], xml::text[], cir::text[] FROM non_string_arrays
+EXCEPT ALL
+SELECT jp::text[], xml::text[], cir::text[] FROM non_string_arrays2;
+
+/****************************************************************************/
+-- Variable length strings.
+CREATE TABLE varchars (
+    vc  VARCHAR    NOT NULL,
+    vcn VARCHAR(8) NOT NULL,
+    bc  VARBIT     NOT NULL,
+    bcn VARBIT(4)  NOT NULL
+);
+
+INSERT INTO varchars
+VALUES ('', '', '', '')
+     , ('   ', '        ', '10100101', '1010')
+     , ('hi there', 'hi you', '0', '0101')
+     , ('😃 🐨 🎱', '是无效的命令', '1', '1100')
+;
+
+COPY varchars TO :'test_url';
+CREATE TABLE varchars2 (LIKE varchars INCLUDING ALL);
+COPY varchars2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM varchars
+EXCEPT ALL
+SELECT * FROM varchars2;
+
+/****************************************************************************/
+-- Variable length string arrays.
+CREATE TABLE varchar_arrays (
+    vc  VARCHAR[]    NOT NULL,
+    vcn VARCHAR(8)[] NOT NULL,
+    bc  VARBIT[]     NOT NULL,
+    bcn VARBIT(4)[]  NOT NULL
+);
+
+INSERT INTO varchar_arrays
+VALUES ('{}', '{}', '{}', '{}')
+     , ('{   }', '{        }', '{10100101}', '{1010}')
+     , ('{hi there, NULL}', '{NULL, hi you}', '{NULL, 0, 1}', '{0101, 0011}')
+     , ('{😃 🐨 🎱}', '{是无效的命令}', '{1, NULL}', '{1100}')
+;
+
+COPY varchar_arrays TO :'test_url';
+CREATE TABLE varchar_arrays2 (LIKE varchar_arrays INCLUDING ALL);
+COPY varchar_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM varchar_arrays
+EXCEPT ALL
+SELECT * FROM varchar_arrays2;
+
+/****************************************************************************/
+-- JSON & UUID values.
+CREATE TABLE json_uuid (
+    u  UUID   NOT NULL,
+    j  JSON   NOT NULL,
+    jb JSONB      NULL
+);
+
+INSERT INTO json_uuid
+VALUES ('00000000-0000-0000-0000-000000000000', 'null', 'null')
+     , ('6ba7b810-9dad-11d1-80b4-00c04fd430c8', '{"x": true}', '{"y": false}')
+     , ('B82601F4-2FF0-4F05-99E4-2CAAC200BA0F', '42', '42')
+     , ('A411B3DC-76c7-4D5D-92B2-3ab802504f1f', '98.6', '98.6')
+     , ('8e6568ce-0cd0-43f0-9118-b2b1171b7a5b', 'true', 'true')
+     , ('CE7F909D-12F6-455E-8C44-80BECE3D5912', '[1, "🖲️", null]', '[1, "🖲️", null]')
+;
+
+COPY json_uuid TO :'test_url';
+CREATE TABLE json_uuid2 (LIKE json_uuid INCLUDING ALL);
+COPY json_uuid2 FROM :'test_url';
+
+-- They should be the same
+SELECT u FROM json_uuid
+EXCEPT ALL
+SELECT u FROM json_uuid2;
+
+SELECT j::text, jb::text FROM json_uuid
+EXCEPT ALL
+SELECT j::text, jb::text FROM json_uuid2;
+
+/****************************************************************************/
+-- JSON & UUID arrays.
+CREATE TABLE json_uuid_arrays (
+    u  UUID[]   NOT NULL,
+    j  JSON[]   NOT NULL,
+    jb JSONB[]      NULL
+);
+
+INSERT INTO json_uuid_arrays
+VALUES ('{00000000-0000-0000-0000-000000000000}', '{null}', '{null}')
+     , ('{}', '{}', '{}')
+     , ('{6ba7b810-9dad-11d1-80b4-00c04fd430c8, NULL}', '{NULL, "{\"x\": true}"}', '{"{\"y\": false}", NULL}')
+     , ('{B82601F4-2FF0-4F05-99E4-2CAAC200BA0F, A411B3DC-76c7-4D5D-92B2-3ab802504f1f}', '{42, 98.6, []}', '{42, 98.6, []}')
+     , ('{NULL}', '{"[1, \"🖲️\", null]"}', '{"[1, \"🖲️\", null]"}')
+;
+
+COPY json_uuid_arrays TO :'test_url';
+CREATE TABLE json_uuid_arrays2 (LIKE json_uuid_arrays INCLUDING ALL);
+COPY json_uuid_arrays2 FROM :'test_url';
+
+-- They should be the same, first comparable values:
+SELECT u FROM json_uuid_arrays
+EXCEPT ALL
+SELECT u FROM json_uuid_arrays2;
+
+-- Cast non-comparable values to text to compare.
+SELECT j::text, jb::text FROM json_uuid_arrays
+EXCEPT ALL
+SELECT j::text, jb::text FROM json_uuid_arrays2;
+
+/****************************************************************************/
+-- Geometric types.
+CREATE TABLE geos (
+    p   point    NOT NULL,
+    line line    NOT NULL,
+    lseg lseg    NOT NULL,
+    box  box     NOT NULL,
+    path path    NOT NULL,
+    poly polygon NOT NULL,
+    cir  circle  NOT NULL
+);
+
+INSERT INTO geos
+VALUES ('0,0', '(1,1),(2,2)', '((11,11),(12,12))', '((11,11),(13,13))', '((11,12),(13,13),(14,14))', '((11,12),(13,13),(14,14))', '1,1,1')
+     , ('(11,nan)', '{nan, 1, nan}', '((11,nan),(nan,12))', '((nan,11),(13,13))', '((11,nan),(13,13),(14,14))', '((11,12),(13,13),(14,nan))', '<(500,500),500>')
+     , ('(11,nan)', '{nan, 1, nan}', '((11,nan),(nan,12))', '((nan,11),(13,13))', '[(11,12),(13,13),(14,14)]', '((11,12),(13,13),(14,nan))', '(0,0),1')
+;
+
+COPY geos TO :'test_url';
+CREATE TABLE geos2 (LIKE geos INCLUDING ALL);
+COPY geos2 FROM :'test_url';
+
+-- They should be the same
+SELECT p::text, line::text, lseg::text, box::text, path::text, poly::text, cir::text FROM geos
+EXCEPT ALL
+SELECT p::text, line::text, lseg::text, box::text, path::text, poly::text, cir::text FROM geos;
+
+/****************************************************************************/
+-- Geometric type arrays.
+CREATE TABLE geo_arrays (
+    p   point[]    NOT NULL,
+    line line[]    NOT NULL,
+    lseg lseg[]    NOT NULL,
+    box  box[]     NOT NULL,
+    path path[]    NOT NULL,
+    poly polygon[] NOT NULL,
+    cir  circle[]  NOT NULL
+);
+
+-- Postgres box arrays use ; as a delimiter.
+INSERT INTO geo_arrays
+VALUES ('{"0,0"}', '{"(1,1),(2,2)"}', '{"((11,11),(12,12))"}', '{"((11,11),(13,13))"}', '{"((11,12),(13,13),(14,14))"}', '{"((11,12),(13,13),(14,14))"}', '{"1,1,1"}')
+     , ('{"(11,nan)", NULL}', '{NULL, "{nan, 1, nan}"}', '{NULL}', '{"((nan,11),(13,13))"; NULL}', '{NULL, "((11,nan),(13,13),(14,14))"}', '{"((11,12),(13,13),(14,nan))", NULL}', '{NULL}')
+;
+
+COPY geo_arrays TO :'test_url';
+CREATE TABLE geo_arrays2 (LIKE geo_arrays INCLUDING ALL);
+COPY geo_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT p::text[], line::text[], lseg::text[], box::text[], path::text[], poly::text[], cir::text[] FROM geo_arrays
+EXCEPT ALL
+SELECT p::text[], line::text[], lseg::text[], box::text[], path::text[], poly::text[], cir::text[] FROM geo_arrays;
+
+/****************************************************************************/
+-- Dates and times.
+CREATE TABLE datetimes (
+    ts    TIMESTAMP          NULL,
+    tsn   TIMESTAMP(3)       NULL,
+    tstz  TIMESTAMPTZ    NOT NULL,
+    tstzn TIMESTAMPTZ(4) NOT NULL,
+    date  DATE           NOT NULL,
+    time  TIME           NOT NULL,
+    timen TIME(3)        NOT NULL,
+    ttz   TIMETZ         NOT NULL,
+    ttzn  TIMETZ(2)      NOT NULL,
+    ival  INTERVAL       NOT NULL
+);
+
+INSERT INTO datetimes
+VALUES ('2026-07-23 20:43:10.836612', '2026-07-23 20:43:27.363', '2026-07-23 20:43:50.944042+00', '2026-07-23 13:44:46.8445-07', '2026-07-23', '13:45:15.416013', '13:45:24.282', '13:45:35.306886-07', '13:45:49.17-07', '1 day')
+     , (NULL, NULL, '2299-12-31 23:59:59.999999Z', '1900-01-01 00:00:00Z', '1900-01-01', '00:00:00', '24:00:00', '00:00:00+1559', '24:00:00-1559', '-178000000 years')
+;
+
+COPY datetimes TO :'test_url';
+CREATE TABLE datetimes2 (LIKE datetimes INCLUDING ALL);
+COPY datetimes2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM datetimes
+EXCEPT ALL
+SELECT * FROM datetimes2;
+
+/****************************************************************************/
+-- Dates and time arrays.
+CREATE TABLE datetime_arrays (
+    ts    TIMESTAMP[]      NOT NULL,
+    tsn   TIMESTAMP(3)[]   NOT NULL,
+    tstz  TIMESTAMPTZ[]    NOT NULL,
+    tstzn TIMESTAMPTZ(4)[] NOT NULL,
+    date  DATE[]           NOT NULL,
+    time  TIME[]           NOT NULL,
+    timen TIME(3)[]        NOT NULL,
+    ttz   TIMETZ[]         NOT NULL,
+    ttzn  TIMETZ(2)[]      NOT NULL,
+    ival  INTERVAL[]       NOT NULL
+);
+
+INSERT INTO datetime_arrays
+VALUES ('{2026-07-23 20:43:10.836612}', '{2026-07-23 20:43:27.363}', '{2026-07-23 20:43:50.944042+00}', '{2026-07-23 13:44:46.8445-07}', '{2026-07-23}', '{13:45:15.416013}', '{13:45:24.282}', '{13:45:35.306886-07}', '{13:45:49.17-07}', '{1 day}')
+     , ('{1900-01-01 00:00:00, 2299-12-31 23:59:59.999999}', '{}', '{1900-01-01 00:00:00Z, 2299-12-31 23:59:59.999999Z}', '{NULL}', '{1900-01-01, 2299-12-31}', '{00:00:00, 24:00:00}', '{NULL}', '{00:00:00+1559, 24:00:00-1559}', '{09:23:23Z}', '{-178000000 years, NULL}')
+;
+COPY datetime_arrays TO :'test_url';
+CREATE TABLE datetime_arrays2 (LIKE datetime_arrays INCLUDING ALL);
+COPY datetime_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM datetime_arrays
+EXCEPT ALL
+SELECT * FROM datetime_arrays2;
+
+/****************************************************************************/
+-- Enums.
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+CREATE TYPE dow AS ENUM ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat');
+CREATE TABLE enums (
+    dow  dow  NOT NULL,
+    mood mood NOT NULL
+);
+
+INSERT INTO enums
+VALUES ('Sun', 'ok')
+     , ('Mon', 'sad')
+     , ('Fri', 'happy')
+;
+
+COPY enums TO :'test_url';
+CREATE TABLE enums2 (LIKE enums INCLUDING ALL);
+COPY enums2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM enums
+EXCEPT ALL
+SELECT * FROM enums2;
+
+/****************************************************************************/
+-- Enum Arrays.
+CREATE TABLE enum_arrays (
+    dow  dow[]  NOT NULL,
+    mood mood[] NOT NULL
+);
+
+INSERT INTO enum_arrays
+VALUES ('{Sun, NULL, Thu}', '{ok, NULL, ok}')
+     , ('{Mon, Tue, Wed}', '{sad, NULL, happy}')
+;
+
+COPY enum_arrays TO :'test_url';
+CREATE TABLE enum_arrays2 (LIKE enum_arrays INCLUDING ALL);
+COPY enum_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM enum_arrays
+EXCEPT ALL
+SELECT * FROM enum_arrays2;
+
+/****************************************************************************/
+-- Network Addresses.
+CREATE TABLE nets (
+    inet INET     NOT NULL,
+    cidr CIDR     NOT NULL,
+    mac  MACADDR  NOT NULL,
+    mac8 MACADDR8 NOT NULL
+);
+
+INSERT INTO nets
+VALUES ('1.2.6.4/16', '121.111.63.82', '22:00:5c:08:55:08', '08:00:2b:01:02:03:04:05')
+     , ('89.225.196.191', '192.168.1.0/24', '08:00:2b:01:02:03', '22:00:5c:08:55:08:01:02')
+     , ('::4:3:2:0/24', '1.2.6.4', '01:02:03:04:05:06', '00:01:03:86:1c:ba')
+;
+
+COPY nets TO :'test_url';
+CREATE TABLE nets2 (LIKE nets INCLUDING ALL);
+COPY nets2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM nets
+EXCEPT ALL
+SELECT * FROM nets2;
+
+/****************************************************************************/
+-- Network Address Arrays.
+CREATE TABLE net_arrays (
+    inet INET[]     NOT NULL,
+    cidr CIDR[]     NOT NULL,
+    mac  MACADDR[]  NOT NULL,
+    mac8 MACADDR8[] NOT NULL
+);
+
+INSERT INTO net_arrays
+VALUES ('{1.2.6.4/16}', '{121.111.63.82}', '{22:00:5c:08:55:08}', '{08:00:2b:01:02:03:04:05}')
+     , ('{89.225.196.191, NULL}', '{NULL}', '{NULL, 08:00:2b:01:02:03}', '{22:00:5c:08:55:08:01:02}')
+     , ('{::4:3:2:0/24, 126::1}', '{1.2.6.4, 126::1}', '{01:02:03:04:05:06, 02:03:04:05:06:07}', '{00:01:03:86:1c:ba, 08002b-010203}')
+;
+
+COPY net_arrays TO :'test_url';
+CREATE TABLE net_arrays2 (LIKE net_arrays INCLUDING ALL);
+COPY net_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM net_arrays
+EXCEPT ALL
+SELECT * FROM net_arrays2;
+\! rm -rf test/types.tmp
+
+/****************************************************************************/
+-- Bit Strings.
+CREATE TABLE bits (
+    b  BIT       NOT NULL,
+    bn BIT(3)    NOT NULL,
+    vb varbit(6) NOT NULL
+);
+
+INSERT INTO bits
+VALUES ('1', '111', '111111')
+     , ('0', '000', '000000')
+     , ('0', '000', '000000')
+;
+
+COPY bits TO :'test_url';
+CREATE TABLE bits2 (LIKE bits INCLUDING ALL);
+COPY bits2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM bits
+EXCEPT ALL
+SELECT * FROM bits2;
+
+
+/****************************************************************************/
+-- Bit String Arrays
+CREATE TABLE bit_arrays (
+    b  BIT[]       NOT NULL,
+    bn BIT(3)[]    NOT NULL,
+    vb varbit(6)[] NOT NULL
+);
+
+INSERT INTO bit_arrays
+VALUES ('{1}', '{111}', '{111111}')
+     , ('{0,1,NULL}', '{000,001,111,110}', '{000000,111001,101010}')
+;
+
+COPY bit_arrays TO :'test_url';
+CREATE TABLE bit_arrays2 (LIKE bit_arrays INCLUDING ALL);
+COPY bit_arrays2 FROM :'test_url';
+
+-- They should be the same
+SELECT * FROM bit_arrays
+EXCEPT ALL
+SELECT * FROM bit_arrays2;


### PR DESCRIPTION
Add `test/sql/types.sql` to test all the core Postgres types round-tripping through TSV file. Organize similarly to `t/structure.pl` to keep thing coherent and orderly to update in the future.

In the process, change the serialization of a number of types to allow them to round-trip properly:

*   Use `String` for `pbchar` rather than `FixedString` because chDB counts bytes while Postgres counts characters. chDB Ignores the typedef on `String(n)`, but keep it for potential future use or output type selection in the future.
*   Use `String` for `json` and `jsonb`, because chDB JSON isn't proper JSON, but an object-based design that does things like drop `null` values.
*   Use `String` for `box` and `polygon` because the text format is incompatible with chDB `Polygon`
*   Always specify precision of `6` in `Time64(6)` and `DateTime64(6)` to preserve the full precision of Postgres `time` and `timestamp` types.
*   Use `String` for `timetz` because there is no corresponding type in chDB and Postgres recommends against its use anyway.
*   Always set the time zone to UTC and the date style to ISO to get consistent timestamp round-tripping regardless of the server or client settings.
*   Also set the client encoding to the database encoding to ensure compatibility of export and import (some encodings use codes unsupported by UTF-8)
*   Use the largest possible `Decimal` size for `numeric` without a typemod, as plane chDB `Decimal` defaults to `Decimal(10, 0)` while plan Postgres `numeric` has only platform-specific size constraints.
*   Use `String` for all arrays, as the `COPY` text format of arrays varies from the chDB `TSV` format (`{}` vs `[]`, double-quotes vs. single quotes). This allows round-tripping, but means that arrays won't be usable as arrays in other systems using, e.g., the avro format. We'll have to upgrade to binary conversion to address this issue.

Adjust `t/structure.pl` to account for these changes, as well.

While at it, release a `HeapTuple` after acquiring it in `format_ch_type()`; Postgres emits a warning without the release.
