### PR TITLE
Add S3 round-trip integration test & fix failures

### DIFF
--- a/.github/actions/setup-pg/action.yml
+++ b/.github/actions/setup-pg/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: "19"
   port:
     description: The Postgres server port for Postgres
-    default: "5432"
+    default: "55435"
     required: false
   packages:
     description: List of additional packages to install"
@@ -27,6 +27,8 @@ runs:
         sudo apt-get install -y postgresql-common ca-certificates build-essential ${{ inputs.packages }}
         sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v ${{ inputs.version }} -i -p
         sudo sed -i 's/#create_main_cluster = true/create_main_cluster = false/' /etc/postgresql-common/createcluster.conf
-        [ "${{ inputs.start }}" == 'yes' ] && sudo pg_createcluster --start ${{ inputs.version }} test -p 55435 -- -A trust
+        if [ "${{ inputs.start }}" == 'yes' ]; then
+          sudo pg_createcluster --start ${{ inputs.version }} test -p ${{ inputs.port }} -- -A trust
+        fi
         echo /usr/lib/postgresql/${{ inputs.version }}/bin >> "$GITHUB_PATH"
-        echo printf 'PGPORT=55435\nPGUSER=postgres\n' >> "$GITHUB_ENV"
+        printf 'PGPORT=${{ inputs.port }}\nPGUSER=postgres\nPG_CONFIG=/usr/lib/postgresql/${{ inputs.version }}/bin/pg_config' >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     - cron: "0 12 10 * *" # Monthly at noon on the tenth
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -20,7 +23,18 @@ jobs:
         uses: actions/checkout@v7
       - name: Start Postgres ${{ matrix.pg }}
         uses: ./.github/actions/setup-pg
-        with: { version: "${{ matrix.pg }}", packages: libkrb5-dev }
+        with:
+          version: ${{ matrix.pg }}
+          packages: libkrb5-dev libipc-run-perl
+      - run: env
+      - name: Configure AWS credentials # for s3.sql round-trip test
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.aws_role_to_assume }}
+          role-session-name: ${{ github.run_id }}
+          aws-region: us-east-2
+      - name: Tweak Permissions # for cache restore
+        run: sudo chmod a+rwx /usr/local/lib /usr/local/include
       - name: Cache chDB
         id: cache-chdb
         uses: actions/cache@v6
@@ -30,13 +44,17 @@ jobs:
             /usr/local/lib/libchdb.so
             /usr/local/include/chdb.*
       - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | bash' || 'ldconfig' }}
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
-      - run: |
-          ls -lah /usr/local/lib/libchdb.so /usr/local/include/chdb.*
-          md5sum /usr/local/lib/libchdb.so /usr/local/include/chdb.h
+      - name: Build
+        run: make -j $(nproc)
+      - name: Install
+        run: sudo make install
       - name: Test
-        run: make -j $(nproc) && make install && make installcheck || find . -name regression.diffs -exec cat {} +
+        run: make installcheck
+      - name: Show Diffs
+        if: failure()
+        run: find . -name regression.diffs -exec cat {} +
       - name: Upload Diffs
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
           packages: libkrb5-dev clang-tidy bear
       - name: Install pre-commit
         run: make debian-install-lint
+      - name: Tweak Permissions # for cache restore
+        run: sudo chmod a+rwx /usr/local/lib /usr/local/include
       - name: Cache chDB
         id: cache-chdb
         uses: actions/cache@v6
@@ -30,7 +32,7 @@ jobs:
             /usr/local/lib/libchdb.so
             /usr/local/include/chdb.*
       - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | bash' || 'ldconfig' }}
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
       - name: Add Postgres to Path
         run: echo /usr/lib/postgresql/${{ env.pg }}/bin >> "$GITHUB_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Start Postgres
         run: pg-start ${{ env.pg }} libkrb5-dev
+      - name: Tweak Permissions # for cache restore
+        run: sudo chmod a+rwx /usr/local/lib /usr/local/include
       - name: Cache chDB
         id: cache-chdb
         uses: actions/cache@v6
@@ -24,11 +26,8 @@ jobs:
             /usr/local/lib/libchdb.so
             /usr/local/include/chdb.*
       - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | bash' || 'ldconfig' }}
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
-      - run: |
-          ls -lah /usr/local/lib/libchdb.so /usr/local/include/chdb.*
-          md5sum /usr/local/lib/libchdb.so /usr/local/include/chdb.h
       - name: Bundle the Release
         id: bundle
         run: pgxn-bundle

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EXTVERSION   = $(shell grep -m 1 'default_version' chdb.control | \
 DISTVERSION  = $(shell grep -m 1 '^[[:space:]]\{2\}"version":' META.json | \
                sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",\{0,1\}/\1/')
 
-MAX_CONCURRENT_TESTS ?= 8
+MAX_CONCURRENT_TESTS ?= 6
 DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql)
 DOCS         = $(wildcard doc/*.md)
 TESTS        ?= $(wildcard test/sql/*.sql)
@@ -29,7 +29,7 @@ include $(PGXS)
 
 # Set default prove flags.
 ifeq ($(PROVE_FLAGS),)
-PROVE_FLAGS = -fwj $(shell nproc)
+PROVE_FLAGS = -fwvj $(shell nproc)
 endif
 
 # Require the versioned SQL script.

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -45,11 +45,19 @@ PG_MODULE_MAGIC_EXT(.name = "chdb_bgw", .version = PGCHCB_VERSION);
 PG_MODULE_MAGIC;
 #endif
 
+/* Define OIDs added in Postgres 19. */
+#if PG_VERSION_NUM <= 190000
+#define OID8OID 6437
+#define OID8ARRAYOID 6442
+#endif
+
 /* Connection to chDB, one per worker. */
 static chdb_connection* chDBConnection = NULL;
 
 /* Streaming result. */
 static chdb_result* chDBStreamingResult = NULL;
+
+static chdb_result* chDBChunkResult = NULL;
 
 /* Insert streaming handle. */
 static chdb_insert_stream chDBInsertStream = NULL;
@@ -498,7 +506,7 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         }
         appendStringInfo(
             query,
-            ") SETTINGS %s, s3_request_timeout_ms = %u",
+            ") SETTINGS %s, s3_request_timeout_ms = %u, s3_truncate_on_insert = 1",
             settings,
             ctx->extra.timeout
         );
@@ -745,28 +753,29 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
     Assert(chDBConnection != NULL);
 
     /* If there are some leftover data from previous read, use it. */
-    if (avail) {
-        if (avail > maxread) {
-            avail = maxread;
-        }
+    while (avail > 0 && maxread > 0 && bytes_read < minread) {
+        avail = Min(avail, maxread);
         memcpy(outbuf, &CopyBuf->data[CopyBuf->cursor], avail);
+        outbuf = (char*)outbuf + avail;
         CopyBuf->cursor += avail;
         maxread -= avail;
         bytes_read += avail;
+        avail = CopyBuf->len - CopyBuf->cursor;
     }
 
-    if (!StreamingInProgress) {
+    if (!StreamingInProgress || avail > 0) {
         return bytes_read;
     }
 
-    chdb_result* chunk;
     while (maxread > 0 && bytes_read < minread) {
+        chdb_destroy_query_result(chDBChunkResult);
         const char* error = NULL;
 
         while (true) {
             CHECK_FOR_INTERRUPTS(); /* Integrate chdb_stream_cancel_query? */
-            chunk = chdb_stream_fetch_result(*chDBConnection, chDBStreamingResult);
-            if (!chunk) {
+            chDBChunkResult =
+                chdb_stream_fetch_result(*chDBConnection, chDBStreamingResult);
+            if (!chDBChunkResult) {
                 chdb_stream_cancel_query(*chDBConnection, chDBStreamingResult);
                 ereport(
                     ERROR,
@@ -775,7 +784,7 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
                 );
             }
 
-            if ((error = chdb_result_error(chunk))) {
+            if ((error = chdb_result_error(chDBChunkResult))) {
                 /* Cut out the request ID line if present. */
                 char* rec_id = strstr(error, "Request ID:");
                 if (rec_id) {
@@ -790,7 +799,6 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
                 }
 
                 error = pstrdup(error);
-                chdb_destroy_query_result(chunk);
                 ereport(
                     ERROR,
                     errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
@@ -800,31 +808,28 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
             }
 
             /* Check if we have data in this chunk. */
-            size_t chunk_length = chdb_result_length(chunk);
+            size_t chunk_length = chdb_result_length(chDBChunkResult);
             if (chunk_length == 0) {
                 /* We're done. */
-                chdb_destroy_query_result(chunk);
+                chdb_destroy_query_result(chDBChunkResult);
                 StreamingInProgress = false;
                 return bytes_read; /* End of stream. */
             }
             Assert(chunk_length <= INT_MAX);
+            Assert(avail == 0);
 
             /* Process the data; borrowed from tablesync.c. */
-            CopyBuf->data   = chdb_result_buffer(chunk);
+            CopyBuf->data   = chdb_result_buffer(chDBChunkResult);
             CopyBuf->len    = (int)chunk_length;
             CopyBuf->cursor = 0;
             // elog(NOTICE, "%s", pnstrdup(CopyBuf->data, CopyBuf->len));
 
-            avail = CopyBuf->len - CopyBuf->cursor;
-            if (avail > maxread) {
-                avail = maxread;
-            }
+            avail = Min(CopyBuf->len, maxread);
             memcpy(outbuf, &CopyBuf->data[CopyBuf->cursor], avail);
             outbuf = (char*)outbuf + avail;
             CopyBuf->cursor += avail;
             maxread -= avail;
             bytes_read += avail;
-            chdb_destroy_query_result(chunk);
 
             if (maxread <= 0 || bytes_read >= minread) {
                 return bytes_read;

--- a/t/structure.pl
+++ b/t/structure.pl
@@ -18,12 +18,13 @@ $node->append_conf(
 $node->start;
 END { $node->stop('fast') }
 
-$node->safe_psql(postgres => 'CREATE EXTENSION chdb');
+$node->psql(postgres => 'CREATE EXTENSION chdb');
 my $port = PostgreSQL::Test::Cluster::get_free_port;
 my $dir = $node->basedir;
 
 NUMBERS: {
-    $node->safe_psql(postgres => q{
+    my ($oid8, $uint64) = $node->pg_version > 19 ? ('OID8', 'UInt64') : ('OID', 'UInt32');
+    $node->psql(postgres => qq{
         CREATE TABLE numbers (
             i2  INT2           NOT NULL,
             i4  INT4           NOT NULL,
@@ -35,7 +36,7 @@ NUMBERS: {
             f8  float8             NULL,
             b   bool           NOT NULL,
             o   OID            NOT NULL,
-            o8  OID8           NOT NULL
+            o8  $oid8          NOT NULL
         )
     });
     check_query(
@@ -43,11 +44,11 @@ NUMBERS: {
         qq{COPY numbers FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
         qr[\QSELECT * FROM file],
-        qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal256(38) NULL, np Decimal(32,0) NULL, nps Decimal(12,6) NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 UInt64" }],
+        qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal256(38) NULL, np Decimal(32,0) NULL, nps Decimal(12,6) NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 $uint64" }],
         # qr[\Q structure: "i2 Int16, i4 Int32, i8 Int64 NULL, num Decimal256(38) NULL, np Decimal(32,0) NULL, nps Decimal(12,6) NULL, f4 Float32, f8 Float64 NULL, b Bool, o UInt32, o8 UInt64" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => qq{
         CREATE TABLE number_arrays (
             i2  INT2[]           NOT NULL,
             i4  INT4[]           NOT NULL,
@@ -59,7 +60,7 @@ NUMBERS: {
             f8  float8[]         NOT NULL,
             b   bool[]           NOT NULL,
             o   OID[]            NOT NULL,
-            o8  OID8[]           NOT NULL
+            o8  ${oid8}[]          NOT NULL
         )
     });
     check_query(
@@ -73,7 +74,7 @@ NUMBERS: {
 }
 
 STRINGS: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE strings (
             t  TEXT    NOT NULL,
             ba BYTEA   NOT NULL,
@@ -88,7 +89,7 @@ STRINGS: {
         qr[\Q structure: "t String, ba String, n String NULL" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE string_arrays (
             t  TEXT[]    NOT NULL,
             ba BYTEA[]   NOT NULL,
@@ -106,7 +107,7 @@ STRINGS: {
 }
 
 FIXIES: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE fixies (
             cr  character(6) NOT NULL,
             ch  char(12)     NOT NULL,
@@ -123,7 +124,7 @@ FIXIES: {
         # qr[\Q structure: "cr FixedString(6), ch FixedString(12), bp String, pbn FixedString(8)" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE fixie_arrays (
             cr  character(6)[] NOT NULL,
             ch  char(12)[]     NOT NULL,
@@ -142,7 +143,7 @@ FIXIES: {
 }
 
 AS_STRINGS: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE non_strings (
             ival INTERVAL NOT NULL,
             tsv  tsvector NOT NULL,
@@ -162,7 +163,7 @@ AS_STRINGS: {
         qr[\Q structure: "ival String, tsv String, tsq String, jp String, mon String, xml String, cir String, na String" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE non_string_arrays (
             ival INTERVAL[] NOT NULL,
             tsv  tsvector[] NOT NULL,
@@ -185,7 +186,7 @@ AS_STRINGS: {
 }
 
 VARCHAR: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE varchars (
             vc  VARCHAR    NOT NULL,
             vcn VARCHAR(8) NOT NULL,
@@ -201,7 +202,7 @@ VARCHAR: {
         qr[\Q structure: "vc String, vcn String(8), bc String, bcn String(4)" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE varchar_arrays (
             vc  VARCHAR[]    NOT NULL,
             vcn VARCHAR(8)[] NOT NULL,
@@ -220,7 +221,7 @@ VARCHAR: {
 }
 
 JSON_UUID: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE json_uuid (
             u  UUID   NOT NULL,
             j  JSON   NOT NULL,
@@ -235,7 +236,7 @@ JSON_UUID: {
         qr[\Q structure: "u UUID, j String, jb String NULL" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE json_uuid_arrays (
             u  UUID[]   NOT NULL,
             j  JSON[]   NOT NULL,
@@ -253,7 +254,7 @@ JSON_UUID: {
 }
 
 GEO: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE geos (
             p   point    NOT NULL,
             line line    NOT NULL,
@@ -272,7 +273,7 @@ GEO: {
         qr[\Q structure: "p Point, line String, lseg String, box String, path String, poly String, cir String" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE geo_arrays (
             p   point[]    NOT NULL,
             line line[]    NOT NULL,
@@ -294,7 +295,7 @@ GEO: {
 }
 
 DATETIME: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE datetime (
             ts    TIMESTAMP          NULL,
             tsn   TIMESTAMP(3)       NULL,
@@ -316,7 +317,7 @@ DATETIME: {
         qr[\Q structure: "ts String NULL, tsn String NULL, tstz DateTime64(6, 'UTC'), tstzn DateTime64(6, 'UTC'), date Date32, "time" Time64(6), timen Time64(6), ttz String, ttzn String, ival String" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE datetime_arrays (
             ts    TIMESTAMP[]      NOT NULL,
             tsn   TIMESTAMP(3)[]   NOT NULL,
@@ -341,14 +342,14 @@ DATETIME: {
 }
 
 ENUMS: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
     });
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TYPE dow AS ENUM ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat');
     });
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE enums (
             mood mood NOT NULL,
             dow  dow  NOT NULL
@@ -362,7 +363,7 @@ ENUMS: {
         qr[\Q structure: "mood String, dow String" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE enum_arrays (
             mood mood[] NOT NULL,
             dow  dow[]  NOT NULL
@@ -379,7 +380,7 @@ ENUMS: {
 }
 
 NETS: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE nets (
             inet INET     NOT NULL,
             cidr CIDR     NOT NULL,
@@ -395,7 +396,7 @@ NETS: {
         qr[\Q structure: "inet String, cidr String, mac String, mac8 String" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE net_arrays (
             inet INET[]     NOT NULL,
             cidr CIDR[]     NOT NULL,
@@ -414,7 +415,7 @@ NETS: {
 }
 
 BITS: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE bits (
             b  BIT       NOT NULL,
             bn BIT(3)    NOT NULL,
@@ -429,7 +430,7 @@ BITS: {
         qr[\Q structure: "b FixedString(1), bn FixedString(3), vb String(6)" }],
     );
 
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE bit_arrays (
             b  BIT[]       NOT NULL,
             bn BIT(3)[]    NOT NULL,
@@ -448,7 +449,7 @@ BITS: {
 }
 
 NAMING: {
-    $node->safe_psql(postgres => q{
+    $node->psql(postgres => q{
         CREATE TABLE "Namings" (
             "ID"        INT  NOT NULL,
             "Full Name" TEXT NOT NULL

--- a/t/table-functions.pl
+++ b/t/table-functions.pl
@@ -33,7 +33,7 @@ subtest s3 => sub {
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 's3://localhost:$port/bucket/prefix/file.csv'},
-        qr/\QFailed to receive table structure/,
+        qr/\QDB::Exception: Message: Access Denied/,
         qr[\QINSERT INTO FUNCTION s3('s3://localhost\E:$port\Q/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
@@ -142,7 +142,7 @@ subtest gcs => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'gcs://example.org/bucket/prefix/file.csv'},
-        qr/HTTP response code: 404/,
+        qr/\QHTTP response code: 404/,
         qr[\QSELECT * FROM gcs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
@@ -166,7 +166,7 @@ subtest gcs => sub {
                 timeout 0
             )
         },
-        qr/HTTP response code: 404/,
+        qr/\QHTTP response code: 404/,
         qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
@@ -178,7 +178,7 @@ subtest http => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'http://example.org/path/file.csv'},
-        qr/HTTP status code: 404/,
+        qr/\QHTTP status code: 404/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
@@ -192,21 +192,21 @@ subtest http => sub {
     check_query(
         $node, 'FROM format, structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (FORMAT 'TabSeparated', structure 'id Int32', timeout 500)},
-        qr/HTTP status code: 404/,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::NetException: Net Exception/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "TabSeparated", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (structure 'id Int32', timeout 1500)},
-        qr/HTTP status code: 404/,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::NoMessageException: No message received/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=2, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO format',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (format 'CSV', timeout 100)},
-        qr/HTTP status code: 404/,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::NoMessageException: No message received/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "CSV", structure: "id Int32 NULL" }],
     );
@@ -342,7 +342,7 @@ subtest hdfs => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv'},
-        qr/Unknown table function hdfs/, # XXX WTF
+        qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
         qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
@@ -357,21 +357,21 @@ subtest hdfs => sub {
     check_query(
         $node, 'FROM url with format and structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (FORMAT 'TSV', STRUCTURE 'a Int8')},
-        qr/Unknown table function hdfs/, # XXX WTF
+        qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
         qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TSV", structure: "a Int8" }],
     );
     check_query(
         $node, 'FROM url with structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (STRUCTURE 'a UInt8')},
-        qr/Unknown table function hdfs/, # XXX WTF
+        qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
         qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "a UInt8" }],
     );
     check_query(
         $node, 'FROM url with format',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (format 'TabSeparated')},
-        qr/Unknown table function hdfs/, # XXX WTF
+        qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
         qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TabSeparated", structure: "id Int32 NULL" }],
     );

--- a/test/expected/as-strings.out
+++ b/test/expected/as-strings.out
@@ -124,4 +124,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/as_strings.tmp
+\set ECHO errors

--- a/test/expected/big-parquet.out
+++ b/test/expected/big-parquet.out
@@ -1,6 +1,5 @@
 LOAD 'chdb';
-\getenv test_dir PG_ABS_SRCDIR
-\set parquet_file file:// :test_dir /big.tmp/big.parquet
+\set parquet_file file:///tmp/big.tmp/big.parquet
 CREATE TYPE http_method AS ENUM(
   'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT',
    'OPTIONS', 'TRACE', 'PATCH', 'QUERY'
@@ -24,7 +23,7 @@ SELECT random(0, +9223372036854775807),
        (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 91 THEN 'GET' WHEN a < 97 THEN 'POST' WHEN a < 99 THEN 'PUT' ELSE (ARRAY['HEAD', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH', 'QUERY'])[random(x-x+1, 7)] END FROM x)::http_method,
        random(1, 8) AS node_id,
        (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 95 THEN 200 WHEN a < 97 THEN 201 WHEN a < 99 THEN 204 ELSE (ARRAY[308, 400, 401, 403, 500])[random(x-x+1, 5)] END FROM x)
--- FROM generate_series(1, 10) x;
+-- FROM generate_series(1, 1000) x;
 FROM generate_series(1, 1260000) x;
 SELECT pg_size_pretty(pg_total_relation_size('logs'));
  pg_size_pretty 
@@ -46,11 +45,13 @@ $$);
 CREATE TABLE imported_logs (LIKE logs INCLUDING ALL);
 COPY imported_logs FROM :'parquet_file';
 -- They should be the same
-SELECT * FROM logs
-EXCEPT ALL
-SELECT * FROM imported_logs;
+WITH x AS (
+    SELECT * FROM logs
+    EXCEPT ALL
+    SELECT * FROM imported_logs
+) SELECT * FROM x LIMIT 10;
  req_id | start_at | duration | resource | method | node_id | response 
 --------+----------+----------+----------+--------+---------+----------
 (0 rows)
 
-\! rm -rf test/big.tmp
+\set ECHO errors

--- a/test/expected/bit-strings.out
+++ b/test/expected/bit-strings.out
@@ -119,4 +119,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/bits.tmp
+\set ECHO errors

--- a/test/expected/datetimes.out
+++ b/test/expected/datetimes.out
@@ -157,10 +157,10 @@ t: RowBinaryWithNamesAndTypes
 t: Parquet
 t: Arrow
 t: ArrowStream
-psql:test/utils/round-trip-formats.sql:337: ERROR:  error fetching chDB query result
-DETAIL:  Code: 321. DB::Exception: Timestamp value in column "tstz" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /Users/david/dev/pgxn/pg_chdb/test/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
+psql:test/utils/round-trip-formats.sql:336: ERROR:  error fetching chDB query result
+DETAIL:  Code: 321. DB::Exception: Timestamp value in column "tstz" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
 CONTEXT:  COPY datetimes2, line 1
-psql:test/utils/round-trip-formats.sql:337: STATEMENT:  COPY "datetimes2" FROM 'file:///Users/david/dev/pgxn/pg_chdb/test/datetimes.tmp' (format 'ORC');
+psql:test/utils/round-trip-formats.sql:336: STATEMENT:  COPY "datetimes2" FROM 'file:///tmp/datetimes.tmp' (format 'ORC');
 f: ORC
 t: Avro
 f: Protobuf
@@ -233,4 +233,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/datetimes.tmp
+\set ECHO errors

--- a/test/expected/enums.out
+++ b/test/expected/enums.out
@@ -119,4 +119,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/enums.tmp
+\set ECHO errors

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -4,6 +4,7 @@ SELECT pgchdb_version() ~ '^\d+\.\d+\.\d+$';
  t
 (1 row)
 
+\set ECHO errors
 SELECT version = pgchdb_version() 
   FROM pg_get_loaded_modules()
  WHERE module_name = 'chdb';

--- a/test/expected/extension_1.out
+++ b/test/expected/extension_1.out
@@ -1,0 +1,8 @@
+SELECT pgchdb_version() ~ '^\d+\.\d+\.\d+$';
+ ?column? 
+----------
+ t
+(1 row)
+
+\set ECHO errors
+SKIP: pg_get_loaded_modules() not defined prior to Postgres 18

--- a/test/expected/file.out
+++ b/test/expected/file.out
@@ -7,10 +7,10 @@ CREATE TABLE requests (
 -- Disable quiet to emit COPY numbers and make NULLs show up
 \pset null '#null#'
 \set QUIET false
--- directory paths are passed to us in environment variables
-\getenv test_dir PG_ABS_SRCDIR
-\set file_base file:// :test_dir /corpus
-\set temp_base file:// :test_dir /file.tmp
+-- Set up paths we'll use.
+\! cp -rf test/corpus /tmp/chdb-corpus
+\set file_base file:///tmp/chdb-corpus
+\set temp_base file:///tmp/file.tmp
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
 COPY 4
@@ -26,11 +26,19 @@ SELECT * FROM requests ORDER BY req_id;
 \set requests_out :temp_base /requests.csv
 COPY requests TO :'requests_out' (structure 'id UInt64, name String, path String');
 COPY 4
-\! cat test/file.tmp/requests.csv
-1,"page_view","/users/profile"
-2,"Page_View","/users/settings"
-3,"PAGE_VIEW","/admin/dashboard"
-4,"add_to_cart","/products/shoes"
+TRUNCATE requests;
+TRUNCATE TABLE
+COPY requests FROM :'requests_out';
+COPY 4
+SELECT * FROM requests ORDER BY req_id;
+ req_id |    name     |       path       
+--------+-------------+------------------
+      1 | page_view   | /users/profile
+      2 | Page_View   | /users/settings
+      3 | PAGE_VIEW   | /admin/dashboard
+      4 | add_to_cart | /products/shoes
+(4 rows)
+
 -- Test importing from ClickHouse with all possible backslash escapes.
 -- https://clickhouse.com/docs/interfaces/formats/TabSeparated
 CREATE TABLE people (
@@ -62,14 +70,6 @@ SELECT * FROM people ORDER BY id;
 \set people_out :temp_base /people.tsv
 COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
 COPY 7
-\! cat test/file.tmp/people.tsv
-1	Obama	Barack	\'Bama to his friends
-2	Clinton	William	Hillary\tChelsea\tSocks\n
-3	Gates	Bill	Dos\r\nWindows\r\nExplorer
-4	Matrix	Dot	a \f b \f c \f \b
-5	Language	C	\N
-6	Others	Some	go \\ get  your  mouse @
-7	Others	Some	go \\ get  your  mouse @
 -- Import it again;
 TRUNCATE people;
 TRUNCATE TABLE
@@ -93,12 +93,23 @@ SELECT * FROM people ORDER BY id;
 -- Export it again, should replace previous.
 COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
 COPY 7
-\! cat test/file.tmp/people.tsv
-1	Obama	Barack	\'Bama to his friends
-2	Clinton	William	Hillary\tChelsea\tSocks\n
-3	Gates	Bill	Dos\r\nWindows\r\nExplorer
-4	Matrix	Dot	a \f b \f c \f \b
-5	Language	C	\N
-6	Others	Some	go \\ get  your  mouse @
-7	Others	Some	go \\ get  your  mouse @
-\! rm -rf test/file.tmp
+TRUNCATE people;
+TRUNCATE TABLE
+COPY people FROM :'people_out';
+COPY 7
+SELECT * FROM people ORDER BY id;
+ id | family_name | given_name |              notes              
+----+-------------+------------+---------------------------------
+  1 | Obama       | Barack     | 'Bama to his friends
+  2 | Clinton     | William    | Hillary Chelsea Socks          +
+    |             |            | 
+  3 | Gates       | Bill       | Dos\r                          +
+    |             |            | Windows\r                      +
+    |             |            | Explorer
+  4 | Matrix      | Dot        | a \x0C b \x0C c \x0C \x08
+  5 | Language    | C          | #null#
+  6 | Others      | Some       | go \ get \x07 your \x0B mouse @
+  7 | Others      | Some       | go \ get \x07 your \x0B mouse @
+(7 rows)
+
+\set ECHO errors

--- a/test/expected/fixies.out
+++ b/test/expected/fixies.out
@@ -124,4 +124,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/fixies.tmp
+\set ECHO errors

--- a/test/expected/geos.out
+++ b/test/expected/geos.out
@@ -130,4 +130,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/geos.tmp
+\set ECHO errors

--- a/test/expected/nets.out
+++ b/test/expected/nets.out
@@ -122,4 +122,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/nets.tmp
+\set ECHO errors

--- a/test/expected/numbers.out
+++ b/test/expected/numbers.out
@@ -1,4 +1,5 @@
 LOAD 'chdb';
+\set ECHO errors
 /****************************************************************************/
 -- Numbers.
 CREATE TABLE numbers (
@@ -13,7 +14,7 @@ CREATE TABLE numbers (
     f8  float8             NULL,
     b   bool           NOT NULL,
     o   OID            NOT NULL,
-    o8  OID8           NOT NULL
+    o8  :oid8          NOT NULL
 );
 INSERT INTO numbers
 VALUES ('00000000-0000-0000-0000-000000000000', 0, 0, 0, 0, 0, 0, 0, 0, false, 0, 0)
@@ -89,7 +90,7 @@ CREATE TABLE number_arrays (
     f8  float8[]         NOT NULL,
     b   bool[]           NOT NULL,
     o   OID[]            NOT NULL,
-    o8  OID8[]           NOT NULL
+    o8  :oid8[]          NOT NULL
 );
 INSERT INTO number_arrays
 VALUES ('{00000000-0000-0000-0000-000000000000}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{0}', '{false}', '{0}', '{0}')
@@ -144,4 +145,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/numbers.tmp
+\set ECHO errors

--- a/test/expected/s3.out
+++ b/test/expected/s3.out
@@ -1,4 +1,5 @@
 LOAD 'chdb';
+-- Simple COPY FROM without credentials.
 CREATE TABLE s3_times (
     id    INT PRIMARY KEY,
     months INT NOT NULL,
@@ -13,14 +14,35 @@ SELECT * FROM s3_times ORDER BY id;
   4 |      5 |    6
 (3 rows)
 
-TRUNCATE s3_times;
-COPY s3_times FROM 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
-SELECT * FROM s3_times ORDER BY id;
- id | months | days 
-----+--------+------
-  1 |      2 |    3
-  3 |      2 |    1
-  4 |      5 |    6
-(3 rows)
-
-TRUNCATE s3_times;
+\set ECHO errors
+-- Create some random data to copy.
+CREATE TABLE s3_things (
+    id       INT  PRIMARY KEY,
+    name     TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+INSERT INTO s3_things
+VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+;
+\set ECHO errors
+-- Copy the data to AWS.
+COPY s3_things TO :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret',
+    session_token :'session_token'
+);
+-- Copy it back.
+CREATE TABLE s3_things2 (LIKE s3_things INCLUDING ALL);
+COPY s3_things2 FROM :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret',
+    session_token :'session_token'
+);
+-- Make sure they're the same.
+WITH x AS (
+    SELECT * FROM s3_things EXCEPT ALL SELECT * FROM s3_things2
+) SELECT COUNT(*) = 0 AS same FROM x \gset
+\set ECHO errors
+Table contents the same

--- a/test/expected/s3_1.out
+++ b/test/expected/s3_1.out
@@ -1,0 +1,18 @@
+LOAD 'chdb';
+-- Simple COPY FROM without credentials.
+CREATE TABLE s3_times (
+    id    INT PRIMARY KEY,
+    months INT NOT NULL,
+    days   INT NOT NULL
+);
+COPY s3_times FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+SELECT * FROM s3_times ORDER BY id;
+ id | months | days 
+----+--------+------
+  1 |      2 |    3
+  3 |      2 |    1
+  4 |      5 |    6
+(3 rows)
+
+\set ECHO errors
+SKIP: No AWS credentials found in the environment

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -124,4 +124,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/strings.tmp
+\set ECHO errors

--- a/test/expected/structures.out
+++ b/test/expected/structures.out
@@ -44,32 +44,32 @@ t: JSONColumnsWithMetadata
 t: JSONCompact
 t: JSONCompactColumns
 t: JSONEachRow
-psql:test/utils/round-trip-formats.sql:171: ERROR:  invalid input syntax for type json
+psql:test/utils/round-trip-formats.sql:170: ERROR:  invalid input syntax for type json
 DETAIL:  The input string ended unexpectedly.
 CONTEXT:  JSON data, line 1: 
 COPY structures2, line 2, column j: ""
-psql:test/utils/round-trip-formats.sql:171: STATEMENT:  COPY "structures2" FROM 'file:///Users/david/dev/pgxn/pg_chdb/test/structures.tmp' (format 'JSONStringsEachRow');
+psql:test/utils/round-trip-formats.sql:170: STATEMENT:  COPY "structures2" FROM 'file:///tmp/structures.tmp' (format 'JSONStringsEachRow');
 f: JSONStringsEachRow
 t: JSONCompactEachRow
-psql:test/utils/round-trip-formats.sql:185: ERROR:  invalid input syntax for type json
+psql:test/utils/round-trip-formats.sql:184: ERROR:  invalid input syntax for type json
 DETAIL:  The input string ended unexpectedly.
 CONTEXT:  JSON data, line 1: 
 COPY structures2, line 2, column j: ""
-psql:test/utils/round-trip-formats.sql:185: STATEMENT:  COPY "structures2" FROM 'file:///Users/david/dev/pgxn/pg_chdb/test/structures.tmp' (format 'JSONCompactStringsEachRow');
+psql:test/utils/round-trip-formats.sql:184: STATEMENT:  COPY "structures2" FROM 'file:///tmp/structures.tmp' (format 'JSONCompactStringsEachRow');
 f: JSONCompactStringsEachRow
 t: JSONCompactEachRowWithNames
 t: JSONCompactEachRowWithNamesAndTypes
-psql:test/utils/round-trip-formats.sql:206: ERROR:  invalid input syntax for type json
+psql:test/utils/round-trip-formats.sql:205: ERROR:  invalid input syntax for type json
 DETAIL:  The input string ended unexpectedly.
 CONTEXT:  JSON data, line 1: 
 COPY structures2, line 2, column j: ""
-psql:test/utils/round-trip-formats.sql:206: STATEMENT:  COPY "structures2" FROM 'file:///Users/david/dev/pgxn/pg_chdb/test/structures.tmp' (format 'JSONCompactStringsEachRowWithNames');
+psql:test/utils/round-trip-formats.sql:205: STATEMENT:  COPY "structures2" FROM 'file:///tmp/structures.tmp' (format 'JSONCompactStringsEachRowWithNames');
 f: JSONCompactStringsEachRowWithNames
-psql:test/utils/round-trip-formats.sql:213: ERROR:  invalid input syntax for type json
+psql:test/utils/round-trip-formats.sql:212: ERROR:  invalid input syntax for type json
 DETAIL:  The input string ended unexpectedly.
 CONTEXT:  JSON data, line 1: 
 COPY structures2, line 2, column j: ""
-psql:test/utils/round-trip-formats.sql:213: STATEMENT:  COPY "structures2" FROM 'file:///Users/david/dev/pgxn/pg_chdb/test/structures.tmp' (format 'JSONCompactStringsEachRowWithNamesAndTypes');
+psql:test/utils/round-trip-formats.sql:212: STATEMENT:  COPY "structures2" FROM 'file:///tmp/structures.tmp' (format 'JSONCompactStringsEachRowWithNamesAndTypes');
 f: JSONCompactStringsEachRowWithNamesAndTypes
 t: JSONObjectEachRow
 t: TSKV
@@ -161,4 +161,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/structures.tmp
+\set ECHO errors

--- a/test/expected/varchars.out
+++ b/test/expected/varchars.out
@@ -123,4 +123,4 @@ t: Protobuf
 t: ProtobufList
 t: MsgPack
 t: BSONEachRow
-\! rm -rf test/varchars.tmp
+\set ECHO errors

--- a/test/sql/as-strings.sql
+++ b/test/sql/as-strings.sql
@@ -44,4 +44,11 @@ CREATE TABLE as_string_arrays2 (LIKE as_string_arrays INCLUDING ALL);
 \set from_table as_string_arrays
 \set to_table as_string_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/as_strings.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/as_strings.tmp
+\endif

--- a/test/sql/big-parquet.sql
+++ b/test/sql/big-parquet.sql
@@ -1,7 +1,6 @@
 LOAD 'chdb';
 
-\getenv test_dir PG_ABS_SRCDIR
-\set parquet_file file:// :test_dir /big.tmp/big.parquet
+\set parquet_file file:///tmp/big.tmp/big.parquet
 
 CREATE TYPE http_method AS ENUM(
   'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT',
@@ -36,7 +35,7 @@ SELECT random(0, +9223372036854775807),
        (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 91 THEN 'GET' WHEN a < 97 THEN 'POST' WHEN a < 99 THEN 'PUT' ELSE (ARRAY['HEAD', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH', 'QUERY'])[random(x-x+1, 7)] END FROM x)::http_method,
        random(1, 8) AS node_id,
        (WITH x(a) AS (select random(x-x+1, 100)) SELECT CASE WHEN a < 95 THEN 200 WHEN a < 97 THEN 201 WHEN a < 99 THEN 204 ELSE (ARRAY[308, 400, 401, 403, 500])[random(x-x+1, 5)] END FROM x)
--- FROM generate_series(1, 10) x;
+-- FROM generate_series(1, 1000) x;
 FROM generate_series(1, 1260000) x;
 
 SELECT pg_size_pretty(pg_total_relation_size('logs'));
@@ -57,8 +56,16 @@ CREATE TABLE imported_logs (LIKE logs INCLUDING ALL);
 COPY imported_logs FROM :'parquet_file';
 
 -- They should be the same
-SELECT * FROM logs
-EXCEPT ALL
-SELECT * FROM imported_logs;
+WITH x AS (
+    SELECT * FROM logs
+    EXCEPT ALL
+    SELECT * FROM imported_logs
+) SELECT * FROM x LIMIT 10;
 
-\! rm -rf test/big.tmp
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/big.tmp
+\endif

--- a/test/sql/bit-strings.sql
+++ b/test/sql/bit-strings.sql
@@ -39,4 +39,11 @@ CREATE TABLE bit_arrays2 (LIKE bit_arrays INCLUDING ALL);
 \set from_table bit_arrays
 \set to_table bit_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/bits.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/bits.tmp
+\endif

--- a/test/sql/datetimes.sql
+++ b/test/sql/datetimes.sql
@@ -65,4 +65,11 @@ CREATE TABLE datetime_arrays2 (LIKE datetime_arrays INCLUDING ALL);
 \set from_table datetime_arrays
 \set to_table datetime_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/datetimes.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/datetimes.tmp
+\endif

--- a/test/sql/enums.sql
+++ b/test/sql/enums.sql
@@ -39,4 +39,11 @@ CREATE TABLE enum_arrays2 (LIKE enum_arrays INCLUDING ALL);
 \set from_table enum_arrays
 \set to_table enum_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/enums.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/enums.tmp
+\endif

--- a/test/sql/extension.sql
+++ b/test/sql/extension.sql
@@ -1,5 +1,13 @@
 SELECT pgchdb_version() ~ '^\d+\.\d+\.\d+$';
 
+\set ECHO errors
+SELECT current_setting('server_version_num')::int < 180000 AS pg17 \gset
+\if :pg17
+\echo 'SKIP: pg_get_loaded_modules() not defined prior to Postgres 18'
+\quit
+\endif
+\set ECHO all
+
 SELECT version = pgchdb_version() 
   FROM pg_get_loaded_modules()
  WHERE module_name = 'chdb';

--- a/test/sql/file.sql
+++ b/test/sql/file.sql
@@ -10,10 +10,10 @@ CREATE TABLE requests (
 \pset null '#null#'
 \set QUIET false
 
--- directory paths are passed to us in environment variables
-\getenv test_dir PG_ABS_SRCDIR
-\set file_base file:// :test_dir /corpus
-\set temp_base file:// :test_dir /file.tmp
+-- Set up paths we'll use.
+\! cp -rf test/corpus /tmp/chdb-corpus
+\set file_base file:///tmp/chdb-corpus
+\set temp_base file:///tmp/file.tmp
 
 \set requests_csv :file_base /requests.csv
 COPY requests FROM :'requests_csv';
@@ -21,7 +21,10 @@ SELECT * FROM requests ORDER BY req_id;
 
 \set requests_out :temp_base /requests.csv
 COPY requests TO :'requests_out' (structure 'id UInt64, name String, path String');
-\! cat test/file.tmp/requests.csv
+
+TRUNCATE requests;
+COPY requests FROM :'requests_out';
+SELECT * FROM requests ORDER BY req_id;
 
 -- Test importing from ClickHouse with all possible backslash escapes.
 -- https://clickhouse.com/docs/interfaces/formats/TabSeparated
@@ -39,7 +42,6 @@ SELECT * FROM people ORDER BY id;
 -- Export back out.
 \set people_out :temp_base /people.tsv
 COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
-\! cat test/file.tmp/people.tsv
 
 -- Import it again;
 TRUNCATE people;
@@ -48,6 +50,15 @@ SELECT * FROM people ORDER BY id;
 
 -- Export it again, should replace previous.
 COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String NULL');
-\! cat test/file.tmp/people.tsv
+TRUNCATE people;
+COPY people FROM :'people_out';
+SELECT * FROM people ORDER BY id;
 
-\! rm -rf test/file.tmp
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/chdb-corpus
+\! rm -rf /tmp/file.tmp
+\endif

--- a/test/sql/fixies.sql
+++ b/test/sql/fixies.sql
@@ -44,4 +44,11 @@ CREATE TABLE fixie_arrays2 (LIKE fixie_arrays INCLUDING ALL);
 \set from_table fixie_arrays
 \set to_table fixie_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/fixies.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/fixies.tmp
+\endif

--- a/test/sql/geos.sql
+++ b/test/sql/geos.sql
@@ -50,4 +50,11 @@ CREATE TABLE geo_arrays2 (LIKE geo_arrays INCLUDING ALL);
 \set to_table geo_arrays2
 \set columns 'p::text[], line::text[], lseg::text[], box::text[], path::text[], poly::text[], cir::text[]'
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/geos.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/geos.tmp
+\endif

--- a/test/sql/nets.sql
+++ b/test/sql/nets.sql
@@ -42,4 +42,11 @@ CREATE TABLE net_arrays2 (LIKE net_arrays INCLUDING ALL);
 \set from_table net_arrays
 \set to_table net_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/nets.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/nets.tmp
+\endif

--- a/test/sql/numbers.sql
+++ b/test/sql/numbers.sql
@@ -1,5 +1,14 @@
 LOAD 'chdb';
 
+\set ECHO errors
+\set oid8 OID8
+SELECT current_setting('server_version_num')::int < 190000 AS pg18 \gset
+\if :pg18
+-- Use OID instead of OID8 prior to Postgres 19.
+\set oid8 OID
+\endif
+\set ECHO all
+
 /****************************************************************************/
 -- Numbers.
 CREATE TABLE numbers (
@@ -14,7 +23,7 @@ CREATE TABLE numbers (
     f8  float8             NULL,
     b   bool           NOT NULL,
     o   OID            NOT NULL,
-    o8  OID8           NOT NULL
+    o8  :oid8          NOT NULL
 );
 
 INSERT INTO numbers
@@ -50,7 +59,7 @@ CREATE TABLE number_arrays (
     f8  float8[]         NOT NULL,
     b   bool[]           NOT NULL,
     o   OID[]            NOT NULL,
-    o8  OID8[]           NOT NULL
+    o8  :oid8[]          NOT NULL
 );
 
 INSERT INTO number_arrays
@@ -64,4 +73,11 @@ CREATE TABLE number_arrays2 (LIKE number_arrays INCLUDING ALL);
 \set from_table number_arrays
 \set to_table number_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/numbers.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/numbers.tmp
+\endif

--- a/test/sql/s3.sql
+++ b/test/sql/s3.sql
@@ -1,5 +1,6 @@
 LOAD 'chdb';
 
+-- Simple COPY FROM without credentials.
 CREATE TABLE s3_times (
     id    INT PRIMARY KEY,
     months INT NOT NULL,
@@ -8,8 +9,69 @@ CREATE TABLE s3_times (
 
 COPY s3_times FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
 SELECT * FROM s3_times ORDER BY id;
-TRUNCATE s3_times;
 
-COPY s3_times FROM 'http://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
-SELECT * FROM s3_times ORDER BY id;
-TRUNCATE s3_times;
+\set ECHO errors
+-- Get AWS credentials from the environment.
+\set access_key ''
+\set access_secret ''
+\getenv access_key AWS_ACCESS_KEY_ID
+\getenv access_secret AWS_SECRET_ACCESS_KEY
+\getenv session_token AWS_SESSION_TOKEN
+SELECT :'access_key' = '' OR :'access_secret' = '' AS no_creds \gset
+
+-- Bail if no credentials.
+\if :no_creds
+\echo 'SKIP: No AWS credentials found in the environment'
+\quit
+\endif
+\set ECHO all
+
+-- Create some random data to copy.
+CREATE TABLE s3_things (
+    id       INT  PRIMARY KEY,
+    name     TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+
+INSERT INTO s3_things
+VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+;
+
+\set ECHO errors
+-- Create URL path to avoid conflicts between concurrent execution.
+\set arch ''
+\getenv arch RUNNER_ARCH
+\set url s3://pg-chdb-ci-248825820370-us-east-2-an/ci/:SERVER_VERSION_NUM :arch /test.csv
+\set ECHO all
+
+-- Copy the data to AWS.
+COPY s3_things TO :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret',
+    session_token :'session_token'
+);
+
+-- Copy it back.
+CREATE TABLE s3_things2 (LIKE s3_things INCLUDING ALL);
+COPY s3_things2 FROM :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret',
+    session_token :'session_token'
+);
+
+-- Make sure they're the same.
+WITH x AS (
+    SELECT * FROM s3_things EXCEPT ALL SELECT * FROM s3_things2
+) SELECT COUNT(*) = 0 AS same FROM x \gset
+
+\set ECHO errors
+\if :same
+\echo 'Table contents the same'
+\else
+\echo 'Table contents differ; want:'
+SELECT * FROM s3_things;
+\echo 'But got'
+SELECT * FROM s3_things2;
+\endif

--- a/test/sql/strings.sql
+++ b/test/sql/strings.sql
@@ -44,4 +44,11 @@ CREATE TABLE string_arrays2 (LIKE string_arrays INCLUDING ALL);
 \set from_table string_arrays
 \set to_table string_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/strings.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/strings.tmp
+\endif

--- a/test/sql/structures.sql
+++ b/test/sql/structures.sql
@@ -61,4 +61,11 @@ CREATE TABLE structure_arrays2 (LIKE structure_arrays INCLUDING ALL);
 \set to_table structure_arrays2
 \set columns 'jp::text[], xml::text[], j::text[], jb::text[]'
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/structures.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/structures.tmp
+\endif

--- a/test/sql/varchars.sql
+++ b/test/sql/varchars.sql
@@ -43,4 +43,11 @@ CREATE TABLE varchar_arrays2 (LIKE varchar_arrays INCLUDING ALL);
 \set from_table varchar_arrays
 \set to_table varchar_arrays2
 \i test/utils/round-trip-formats.sql
-\! rm -rf test/varchars.tmp
+
+\set ECHO errors
+\set ci ''
+\getenv ci CI
+SELECT :'ci' = '' AS not_ci \gset
+\if :not_ci
+\! rm -rf /tmp/varchars.tmp
+\endif

--- a/test/utils/round-trip-formats.sql
+++ b/test/utils/round-trip-formats.sql
@@ -7,8 +7,7 @@
 --
 -- https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table)
 
-\getenv test_dir PG_ABS_SRCDIR
-\set test_url file:// :test_dir / :output_fle
+\set test_url file:///tmp/ :output_fle
 \pset tuples_only on
 \pset format unaligned
 \pset fieldsep ': '


### PR DESCRIPTION
Revise `test/sql/s3.sql` to read the AWS credential environment variables and, if they're set, copy random data to S3, then copy it back to a new table to ensure the data hasn't changed. This test turned up a bug where the `COPY` would fail if the file already existed on S3; add `s3_truncate_on_insert = 1` to the settings to resolve the issue.

These changes somehow increase the number of background workers that can be used in parallel tests, so reduce the default number of parallel tests to 6. It also changed some of the error responses in `t/table-functions.pl`, so fix those, too.

Add the `configure-aws-credentials` step to the CI workflow. This action configures the AWS credential environment variables via an SSO-backed flow so that `s3.sql` can use them to test against a real bucket. While at it, fix a permissions issue that caused cache restoration to fail and use `sudo` to run commands. Also remove an old debugging step, install IPC::Run, and restore the proper exit status on test failure by using more discreet steps.

The restoration of the exit status revealed a number of failures that have been broken since it was introduced. To fix them:

*   Define `OID8OID` and `OID8ARRAYOID` prior to Postgres 19
*   Use `OID` instead of `OID8` prior to Postgres 19 in `numbers.sql` and `structure.pl` (and use `psql` instead of `safe_psql` to surface errors).
*   Skip the `pg_get_loaded_modules()` test prior to Postgres 18
*   Use `/tmp` for all files the server works with, copying the corpus when necessary, so that the server definitely has access to them and locations that show up in some error aren't hard-coded location of the repo on my Mac.
*   Cease `cat`ing exported files, as the user running the test may not have read access to the files exported by the Postgres server user, as in the GitHub workflow.
*   Limit the output of the `EXCEPT` query in `test/sql/big-parquet.sql` to 10 rows so as not to inundate the user on test failure.
*   Properly set `PGPORT` and also explicitly set `PG_CONFIG` in `.github/actions/setup-pg/action.yml`.
*   Move the result chunk used by `fetch_chdb_data()` to a global, because its data is copied by reference into the buffer, so the next time `fetch_chdb_data()` runs and finds more in the buffer, it's still there.