### PR TITLE
Simplify deletion and fix variable typo

### DIFF
--- a/test/expected/as-strings.out
+++ b/test/expected/as-strings.out
@@ -16,7 +16,7 @@ VALUES ('02:00:00', 'a fat cat', 'fat & rat', '100')
 CREATE TABLE as_strings2 (LIKE as_strings INCLUDING ALL);
 \set from_table as_strings
 \set to_table as_strings2
-\set output_fle as_strings.tmp
+\set output_file as_strings.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/bit-strings.out
+++ b/test/expected/bit-strings.out
@@ -15,7 +15,7 @@ VALUES ('1', '111', '111111')
 CREATE TABLE bits2 (LIKE bits INCLUDING ALL);
 \set from_table bits
 \set to_table bits2
-\set output_fle bits.tmp
+\set output_file bits.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/datetimes.out
+++ b/test/expected/datetimes.out
@@ -22,7 +22,7 @@ VALUES ('2026-07-23 20:43:10', '2026-07-23 20:43:27', '2026-07-23 20:43:50+00', 
 CREATE TABLE datetimes2 (LIKE datetimes INCLUDING ALL);
 \set from_table datetimes
 \set to_table datetimes2
-\set output_fle datetimes.tmp
+\set output_file datetimes.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/enums.out
+++ b/test/expected/enums.out
@@ -16,7 +16,7 @@ VALUES ('Sun', 'ok')
 CREATE TABLE enums2 (LIKE enums INCLUDING ALL);
 \set from_table enums
 \set to_table enums2
-\set output_fle enums.tmp
+\set output_file enums.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/fixies.out
+++ b/test/expected/fixies.out
@@ -15,7 +15,7 @@ VALUES ('      ', '            ', ' ', '        ')
 ;
 -- Execute round-trip to all supported formats.
 CREATE TABLE fixies2 (LIKE fixies INCLUDING ALL);
-\set output_fle fixies.tmp
+\set output_file fixies.tmp
 \set from_table fixies
 \set to_table fixies2
 \i test/utils/round-trip-formats.sql

--- a/test/expected/geos.out
+++ b/test/expected/geos.out
@@ -19,7 +19,7 @@ VALUES ('0,0', '(1,1),(2,2)', '((11,11),(12,12))', '((11,11),(13,13))', '((11,12
 CREATE TABLE geos2 (LIKE geos INCLUDING ALL);
 \set from_table geos
 \set to_table geos2
-\set output_fle geos.tmp
+\set output_file geos.tmp
 \set columns 'p::text, line::text, lseg::text, box::text, path::text, poly::text, cir::text'
 \i test/utils/round-trip-formats.sql
 \set ECHO errors

--- a/test/expected/nets.out
+++ b/test/expected/nets.out
@@ -16,7 +16,7 @@ VALUES ('1.2.6.4/16', '121.111.63.82', '22:00:5c:08:55:08', '08:00:2b:01:02:03:0
 CREATE TABLE nets2 (LIKE nets INCLUDING ALL);
 \set from_table nets
 \set to_table nets2
-\set output_fle nets.tmp
+\set output_file nets.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/numbers.out
+++ b/test/expected/numbers.out
@@ -31,7 +31,7 @@ VALUES ('00000000-0000-0000-0000-000000000000', 0, 0, 0, 0, 0, 0, 0, 0, false, 0
 CREATE TABLE numbers2 (LIKE numbers INCLUDING ALL);
 \set from_table numbers
 \set to_table numbers2
-\set output_fle numbers.tmp
+\set output_file numbers.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/strings.out
+++ b/test/expected/strings.out
@@ -18,7 +18,7 @@ VALUES ('', '', '')
 CREATE TABLE strings2 (LIKE strings INCLUDING ALL);
 \set from_table strings
 \set to_table strings2
-\set output_fle strings.tmp
+\set output_file strings.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/expected/structures.out
+++ b/test/expected/structures.out
@@ -20,7 +20,7 @@ VALUES ('$.x', '<html>hi</html>', '{"x": true}', '{"y": false}')
 CREATE TABLE structures2 (LIKE structures INCLUDING ALL);
 \set from_table structures
 \set to_table structures2
-\set output_fle structures.tmp
+\set output_file structures.tmp
 \set columns 'jp::text, xml::text, j::text, jb::text'
 \i test/utils/round-trip-formats.sql
 \set ECHO errors

--- a/test/expected/varchars.out
+++ b/test/expected/varchars.out
@@ -17,7 +17,7 @@ VALUES ('', '', '', '')
 CREATE TABLE varchars2 (LIKE varchars INCLUDING ALL);
 \set from_table varchars
 \set to_table varchars2
-\set output_fle varchars.tmp
+\set output_file varchars.tmp
 \i test/utils/round-trip-formats.sql
 \set ECHO errors
 t: TabSeparated

--- a/test/sql/as-strings.sql
+++ b/test/sql/as-strings.sql
@@ -19,7 +19,7 @@ VALUES ('02:00:00', 'a fat cat', 'fat & rat', '100')
 CREATE TABLE as_strings2 (LIKE as_strings INCLUDING ALL);
 \set from_table as_strings
 \set to_table as_strings2
-\set output_fle as_strings.tmp
+\set output_file as_strings.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -44,11 +44,5 @@ CREATE TABLE as_string_arrays2 (LIKE as_string_arrays INCLUDING ALL);
 \set from_table as_string_arrays
 \set to_table as_string_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/as_strings.tmp
-\endif
+\! rm -rf /tmp/as_strings.tmp 2> /dev/null || true

--- a/test/sql/big-parquet.sql
+++ b/test/sql/big-parquet.sql
@@ -63,9 +63,4 @@ WITH x AS (
 ) SELECT * FROM x LIMIT 10;
 
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/big.tmp
-\endif
+\! rm -rf /tmp/big.tmp 2> /dev/null || true

--- a/test/sql/bit-strings.sql
+++ b/test/sql/bit-strings.sql
@@ -18,7 +18,7 @@ VALUES ('1', '111', '111111')
 CREATE TABLE bits2 (LIKE bits INCLUDING ALL);
 \set from_table bits
 \set to_table bits2
-\set output_fle bits.tmp
+\set output_file bits.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -39,11 +39,5 @@ CREATE TABLE bit_arrays2 (LIKE bit_arrays INCLUDING ALL);
 \set from_table bit_arrays
 \set to_table bit_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/bits.tmp
-\endif
+\! rm -rf /tmp/bits.tmp 2> /dev/null || true

--- a/test/sql/datetimes.sql
+++ b/test/sql/datetimes.sql
@@ -25,7 +25,7 @@ VALUES ('2026-07-23 20:43:10', '2026-07-23 20:43:27', '2026-07-23 20:43:50+00', 
 CREATE TABLE datetimes2 (LIKE datetimes INCLUDING ALL);
 \set from_table datetimes
 \set to_table datetimes2
-\set output_fle datetimes.tmp
+\set output_file datetimes.tmp
 \i test/utils/round-trip-formats.sql
 
 -- Add timestamps with sub-second precision. Protobuf truncates seconds so
@@ -65,11 +65,5 @@ CREATE TABLE datetime_arrays2 (LIKE datetime_arrays INCLUDING ALL);
 \set from_table datetime_arrays
 \set to_table datetime_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/datetimes.tmp
-\endif
+\! rm -rf /tmp/datetimes.tmp 2> /dev/null || true

--- a/test/sql/enums.sql
+++ b/test/sql/enums.sql
@@ -19,7 +19,7 @@ VALUES ('Sun', 'ok')
 CREATE TABLE enums2 (LIKE enums INCLUDING ALL);
 \set from_table enums
 \set to_table enums2
-\set output_fle enums.tmp
+\set output_file enums.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -39,11 +39,5 @@ CREATE TABLE enum_arrays2 (LIKE enum_arrays INCLUDING ALL);
 \set from_table enum_arrays
 \set to_table enum_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/enums.tmp
-\endif
+\! rm -rf /tmp/enums.tmp 2> /dev/null || true

--- a/test/sql/file.sql
+++ b/test/sql/file.sql
@@ -53,12 +53,6 @@ COPY people TO :'people_out' (structure 'i Int32, f String, g String, n String N
 TRUNCATE people;
 COPY people FROM :'people_out';
 SELECT * FROM people ORDER BY id;
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/chdb-corpus
-\! rm -rf /tmp/file.tmp
-\endif
+\! rm -rf /tmp/file.tmp 2> /dev/null || true
+\! rm -rf /tmp/chdb-corpus 2> /dev/null || true

--- a/test/sql/fixies.sql
+++ b/test/sql/fixies.sql
@@ -18,7 +18,7 @@ VALUES ('      ', '            ', ' ', '        ')
 
 -- Execute round-trip to all supported formats.
 CREATE TABLE fixies2 (LIKE fixies INCLUDING ALL);
-\set output_fle fixies.tmp
+\set output_file fixies.tmp
 \set from_table fixies
 \set to_table fixies2
 \i test/utils/round-trip-formats.sql
@@ -44,11 +44,5 @@ CREATE TABLE fixie_arrays2 (LIKE fixie_arrays INCLUDING ALL);
 \set from_table fixie_arrays
 \set to_table fixie_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/fixies.tmp
-\endif
+\! rm -rf /tmp/fixies.tmp 2> /dev/null || true

--- a/test/sql/geos.sql
+++ b/test/sql/geos.sql
@@ -22,7 +22,7 @@ VALUES ('0,0', '(1,1),(2,2)', '((11,11),(12,12))', '((11,11),(13,13))', '((11,12
 CREATE TABLE geos2 (LIKE geos INCLUDING ALL);
 \set from_table geos
 \set to_table geos2
-\set output_fle geos.tmp
+\set output_file geos.tmp
 \set columns 'p::text, line::text, lseg::text, box::text, path::text, poly::text, cir::text'
 \i test/utils/round-trip-formats.sql
 
@@ -50,11 +50,5 @@ CREATE TABLE geo_arrays2 (LIKE geo_arrays INCLUDING ALL);
 \set to_table geo_arrays2
 \set columns 'p::text[], line::text[], lseg::text[], box::text[], path::text[], poly::text[], cir::text[]'
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/geos.tmp
-\endif
+\! rm -rf /tmp/geos.tmp 2> /dev/null || true

--- a/test/sql/nets.sql
+++ b/test/sql/nets.sql
@@ -19,7 +19,7 @@ VALUES ('1.2.6.4/16', '121.111.63.82', '22:00:5c:08:55:08', '08:00:2b:01:02:03:0
 CREATE TABLE nets2 (LIKE nets INCLUDING ALL);
 \set from_table nets
 \set to_table nets2
-\set output_fle nets.tmp
+\set output_file nets.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -42,11 +42,5 @@ CREATE TABLE net_arrays2 (LIKE net_arrays INCLUDING ALL);
 \set from_table net_arrays
 \set to_table net_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/nets.tmp
-\endif
+\! rm -rf /tmp/nets.tmp 2> /dev/null || true

--- a/test/sql/numbers.sql
+++ b/test/sql/numbers.sql
@@ -42,7 +42,7 @@ VALUES ('00000000-0000-0000-0000-000000000000', 0, 0, 0, 0, 0, 0, 0, 0, false, 0
 CREATE TABLE numbers2 (LIKE numbers INCLUDING ALL);
 \set from_table numbers
 \set to_table numbers2
-\set output_fle numbers.tmp
+\set output_file numbers.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -73,11 +73,5 @@ CREATE TABLE number_arrays2 (LIKE number_arrays INCLUDING ALL);
 \set from_table number_arrays
 \set to_table number_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/numbers.tmp
-\endif
+\! rm -rf /tmp/numbers.tmp 2> /dev/null || true

--- a/test/sql/s3.sql
+++ b/test/sql/s3.sql
@@ -40,10 +40,11 @@ VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (ran
 ;
 
 \set ECHO errors
--- Create URL path to avoid conflicts between concurrent execution.
+-- Create unique URL path to avoid conflicts between concurrent execution.
+SELECT (random() * 100000)::int AS rand \gset
 \set arch ''
 \getenv arch RUNNER_ARCH
-\set url s3://pg-chdb-ci-248825820370-us-east-2-an/ci/:SERVER_VERSION_NUM :arch /test.csv
+\set url s3://pg-chdb-ci-248825820370-us-east-2-an/ci/:SERVER_VERSION_NUM - :arch - :rand /test.csv
 \set ECHO all
 
 -- Copy the data to AWS.

--- a/test/sql/strings.sql
+++ b/test/sql/strings.sql
@@ -21,7 +21,7 @@ VALUES ('', '', '')
 CREATE TABLE strings2 (LIKE strings INCLUDING ALL);
 \set from_table strings
 \set to_table strings2
-\set output_fle strings.tmp
+\set output_file strings.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -44,11 +44,5 @@ CREATE TABLE string_arrays2 (LIKE string_arrays INCLUDING ALL);
 \set from_table string_arrays
 \set to_table string_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/strings.tmp
-\endif
+\! rm -rf /tmp/strings.tmp 2> /dev/null || true

--- a/test/sql/structures.sql
+++ b/test/sql/structures.sql
@@ -23,7 +23,7 @@ VALUES ('$.x', '<html>hi</html>', '{"x": true}', '{"y": false}')
 CREATE TABLE structures2 (LIKE structures INCLUDING ALL);
 \set from_table structures
 \set to_table structures2
-\set output_fle structures.tmp
+\set output_file structures.tmp
 \set columns 'jp::text, xml::text, j::text, jb::text'
 \i test/utils/round-trip-formats.sql
 
@@ -61,11 +61,5 @@ CREATE TABLE structure_arrays2 (LIKE structure_arrays INCLUDING ALL);
 \set to_table structure_arrays2
 \set columns 'jp::text[], xml::text[], j::text[], jb::text[]'
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/structures.tmp
-\endif
+\! rm -rf /tmp/structures.tmp 2> /dev/null || true

--- a/test/sql/varchars.sql
+++ b/test/sql/varchars.sql
@@ -20,7 +20,7 @@ VALUES ('', '', '', '')
 CREATE TABLE varchars2 (LIKE varchars INCLUDING ALL);
 \set from_table varchars
 \set to_table varchars2
-\set output_fle varchars.tmp
+\set output_file varchars.tmp
 \i test/utils/round-trip-formats.sql
 
 /****************************************************************************/
@@ -43,11 +43,5 @@ CREATE TABLE varchar_arrays2 (LIKE varchar_arrays INCLUDING ALL);
 \set from_table varchar_arrays
 \set to_table varchar_arrays2
 \i test/utils/round-trip-formats.sql
-
 \set ECHO errors
-\set ci ''
-\getenv ci CI
-SELECT :'ci' = '' AS not_ci \gset
-\if :not_ci
-\! rm -rf /tmp/varchars.tmp
-\endif
+\! rm -rf /tmp/varchars.tmp 2> /dev/null || true

--- a/test/utils/round-trip-formats.sql
+++ b/test/utils/round-trip-formats.sql
@@ -7,7 +7,7 @@
 --
 -- https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table)
 
-\set test_url file:///tmp/ :output_fle
+\set test_url file:///tmp/ :output_file
 \pset tuples_only on
 \pset format unaligned
 \pset fieldsep ': '


### PR DESCRIPTION
Rather than attempting to determine whether we're running in CI, just run `rm -rf` and ignore errors. Also rename `output_fle` to `output_file`.