### PR TITLE
Add GCS round-trip test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           version: ${{ matrix.pg }}
           packages: libkrb5-dev libipc-run-perl
-      - run: env
       - name: Configure AWS credentials # for s3.sql round-trip test
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -52,6 +51,10 @@ jobs:
         run: sudo make install
       - name: Test
         run: make installcheck
+        # https://console.cloud.google.com/storage/settings;tab=interoperability?project=ch-pg-test
+        env:
+          CLOUDSDK_AUTH_HMAC_KEY: ${{ secrets.gcp_hmac_key }}
+          CLOUDSDK_AUTH_HMAC_SECRET: ${{ secrets.gcp_hmac_secret }}
       - name: Show Diffs
         if: failure()
         run: find . -name regression.diffs -exec cat {} +

--- a/test/expected/gcs.out
+++ b/test/expected/gcs.out
@@ -1,4 +1,5 @@
 LOAD 'chdb';
+-- Simple COPY FROM without credentials.
 CREATE TABLE gcs_times (
     id    INT PRIMARY KEY,
     months INT NOT NULL,
@@ -13,4 +14,38 @@ SELECT * FROM gcs_times ORDER BY id;
   4 |      5 |    6
 (3 rows)
 
-TRUNCATE gcs_times;
+\set ECHO errors
+-- Create some random data to copy.
+CREATE TABLE gcs_things (
+    id       INT  PRIMARY KEY,
+    name     TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+INSERT INTO gcs_things
+VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+;
+-- Copy to existing file to ensure s3_truncate_on_insert is true.
+COPY gcs_things TO 'gs://storage.googleapis.com/pg-chdb-ci/keep-me.tsv' (
+    access_key :'access_key',
+    access_secret :'access_secret'
+);
+\set ECHO errors
+-- Copy the data to GCS.
+COPY gcs_things TO :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret'
+);
+-- Copy it back.
+CREATE TABLE gcs_things2 (LIKE gcs_things INCLUDING ALL);
+COPY gcs_things2 FROM :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret'
+);
+-- Make sure they're the same.
+WITH x AS (
+    SELECT * FROM gcs_things EXCEPT ALL SELECT * FROM gcs_things2
+) SELECT COUNT(*) = 0 AS same FROM x \gset
+\set ECHO errors
+Table contents the same

--- a/test/expected/gcs_1.out
+++ b/test/expected/gcs_1.out
@@ -1,0 +1,18 @@
+LOAD 'chdb';
+-- Simple COPY FROM without credentials.
+CREATE TABLE gcs_times (
+    id    INT PRIMARY KEY,
+    months INT NOT NULL,
+    days   INT NOT NULL
+);
+COPY gcs_times FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+SELECT * FROM gcs_times ORDER BY id;
+ id | months | days 
+----+--------+------
+  1 |      2 |    3
+  3 |      2 |    1
+  4 |      5 |    6
+(3 rows)
+
+\set ECHO errors
+SKIP: No GCP credentials found in the environment

--- a/test/expected/s3.out
+++ b/test/expected/s3.out
@@ -26,8 +26,14 @@ VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (ran
      , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
      , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
 ;
+-- Copy to existing file to ensure s3_truncate_on_insert is true.
+COPY s3_things TO 's3://pg-chdb-ci-248825820370-us-east-2-an/keep-me.tsv' (
+    access_key :'access_key',
+    access_secret :'access_secret',
+    session_token :'session_token'
+);
 \set ECHO errors
--- Copy the data to AWS.
+-- Copy the data to S3.
 COPY s3_things TO :'url' (
     access_key :'access_key',
     access_secret :'access_secret',

--- a/test/sql/gcs.sql
+++ b/test/sql/gcs.sql
@@ -1,5 +1,6 @@
 LOAD 'chdb';
 
+-- Simple COPY FROM without credentials.
 CREATE TABLE gcs_times (
     id    INT PRIMARY KEY,
     months INT NOT NULL,
@@ -8,4 +9,73 @@ CREATE TABLE gcs_times (
 
 COPY gcs_times FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
 SELECT * FROM gcs_times ORDER BY id;
-TRUNCATE gcs_times;
+
+\set ECHO errors
+-- Get GCP credentials from the environment.
+\set access_key ''
+\set access_secret ''
+\getenv access_key CLOUDSDK_AUTH_HMAC_KEY
+\getenv access_secret CLOUDSDK_AUTH_HMAC_SECRET
+SELECT :'access_key' = '' OR :'access_secret' = '' AS no_creds \gset
+
+-- Bail if no credentials.
+\if :no_creds
+\echo 'SKIP: No GCP credentials found in the environment'
+\quit
+\endif
+\set ECHO all
+
+-- Create some random data to copy.
+CREATE TABLE gcs_things (
+    id       INT  PRIMARY KEY,
+    name     TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+
+INSERT INTO gcs_things
+VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+;
+
+-- Copy to existing file to ensure s3_truncate_on_insert is true.
+COPY gcs_things TO 'gs://storage.googleapis.com/pg-chdb-ci/keep-me.tsv' (
+    access_key :'access_key',
+    access_secret :'access_secret'
+);
+
+\set ECHO errors
+-- Create unique URL path to avoid conflicts between concurrent execution.
+SELECT (random() * 100000)::int AS rand \gset
+\set arch ''
+\getenv arch RUNNER_ARCH
+\set url gs://storage.googleapis.com/pg-chdb-ci/ci/:SERVER_VERSION_NUM - :arch - :rand /test.csv
+\set ECHO all
+
+-- Copy the data to GCS.
+COPY gcs_things TO :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret'
+);
+
+-- Copy it back.
+CREATE TABLE gcs_things2 (LIKE gcs_things INCLUDING ALL);
+COPY gcs_things2 FROM :'url' (
+    access_key :'access_key',
+    access_secret :'access_secret'
+);
+
+-- Make sure they're the same.
+WITH x AS (
+    SELECT * FROM gcs_things EXCEPT ALL SELECT * FROM gcs_things2
+) SELECT COUNT(*) = 0 AS same FROM x \gset
+
+\set ECHO errors
+\if :same
+\echo 'Table contents the same'
+\else
+\echo 'Table contents differ; want:'
+SELECT * FROM gcs_things;
+\echo 'But got'
+SELECT * FROM gcs_things2;
+\endif

--- a/test/sql/s3.sql
+++ b/test/sql/s3.sql
@@ -39,6 +39,13 @@ VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (ran
      , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
 ;
 
+-- Copy to existing file to ensure s3_truncate_on_insert is true.
+COPY s3_things TO 's3://pg-chdb-ci-248825820370-us-east-2-an/keep-me.tsv' (
+    access_key :'access_key',
+    access_secret :'access_secret',
+    session_token :'session_token'
+);
+
 \set ECHO errors
 -- Create unique URL path to avoid conflicts between concurrent execution.
 SELECT (random() * 100000)::int AS rand \gset
@@ -47,7 +54,7 @@ SELECT (random() * 100000)::int AS rand \gset
 \set url s3://pg-chdb-ci-248825820370-us-east-2-an/ci/:SERVER_VERSION_NUM - :arch - :rand /test.csv
 \set ECHO all
 
--- Copy the data to AWS.
+-- Copy the data to S3.
 COPY s3_things TO :'url' (
     access_key :'access_key',
     access_secret :'access_secret',


### PR DESCRIPTION
Depends on environment variables for the `hmac_key` and `hmac_secret` that the ClickHouse `gcs()` function expects. Simply addGH action secrets with their values and set the environment variables.

Also add a `COPY TO` command to a static S3 location to ensure that `s3_truncate_on_insert` is true and thus doesn't error out when the file already exists. Do the same in the GCS test, too.

Remove a wayward `run: env` command left from a previous commit.