### PR TITLE
Upgrade to chDB v26.5.1-rc.3, update workarounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         arch: [amd64, arm64]
     name: 🐘 PostgreSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }}
     runs-on: ubuntu-${{ matrix.arch == 'amd64' && 'latest' || '24.04-arm' }}
-    env: { chdb_version: v26.5.1-rc.2 }
+    env: { chdb_version: v26.5.1-rc.3 }
     steps:
       - name: Checkout the Repository
         uses: actions/checkout@v7
@@ -43,7 +43,7 @@ jobs:
             /usr/local/lib/libchdb.so
             /usr/local/include/chdb.*
       - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo bash' || 'sudo ldconfig' }}
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
       - name: Build
         run: make -j $(nproc)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     name: 🔎 Lint Code
     runs-on: ubuntu-latest
-    env: { pg: 19, chdb_version: v26.5.1-rc.2 }
+    env: { pg: 19, chdb_version: v26.5.1-rc.3 }
     steps:
       - name: Checkout the Repository
         uses: actions/checkout@v7
@@ -32,7 +32,7 @@ jobs:
             /usr/local/lib/libchdb.so
             /usr/local/include/chdb.*
       - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo bash' || 'sudo ldconfig' }}
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
       - name: Add Postgres to Path
         run: echo /usr/lib/postgresql/${{ env.pg }}/bin >> "$GITHUB_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Release on GitHub and PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
-    env: { pg: 19, chdb_version: v26.5.1-rc.2 }
+    env: { pg: 19, chdb_version: v26.5.1-rc.3 }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -26,7 +26,7 @@ jobs:
             /usr/local/lib/libchdb.so
             /usr/local/include/chdb.*
       - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo bash' || 'sudo ldconfig' }}
+        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
       - name: Bundle the Release
         id: bundle

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -69,9 +69,6 @@ static StringInfo CopyBuf = NULL;
 /* Bytes to accumulate before pushing to chDB */
 #define CHDB_COPY_CHUNK_SIZE (64 * 1024)
 
-/* Indicates whether streaming is in progress. */
-static bool StreamingInProgress = false;
-
 /* Returns the ClickHouse type name that corresponds to the `attr` type. */
 static const char*
 chdb_type_for(chdbCopyContext* ctx, Form_pg_attribute attr);
@@ -236,7 +233,6 @@ chdb_bgw_main(Datum main_arg) {
     Assert(chDBStreamingResult == NULL);
     Assert(chDBInsertStream == NULL);
     Assert(CopyBuf == NULL);
-    Assert(!StreamingInProgress);
 
     /*
      * Connect to chDB. It will use a temporary directory that it cleans up
@@ -314,7 +310,6 @@ chdb_bgw_main(Datum main_arg) {
         }
 
         /* Process chunks. */
-        StreamingInProgress = true;
         PG_TRY();
         {
             CopyBuf = makeStringInfo();
@@ -338,14 +333,20 @@ chdb_bgw_main(Datum main_arg) {
             PopActiveSnapshot();
             AbortCurrentTransaction();
             chdb_destroy_query_result(chDBStreamingResult);
-            chDBInsertStream    = NULL;
-            StreamingInProgress = false;
+            chDBInsertStream = NULL;
             PG_RE_THROW();
         }
         PG_END_TRY();
     } else {
         /* Start the streaming insert. */
-        chDBInsertStream = chdb_stream_insert(*chDBConnection, ch_query.data, "TSV");
+        chDBInsertStream = chdb_stream_insert_with_params(
+            *chDBConnection,
+            ch_query.data,
+            "TSV",
+            (const char* const*)names,
+            (const char* const*)values,
+            param_count
+        );
 
         /* Check for errors. */
         if ((error = chdb_stream_insert_error(chDBInsertStream))) {
@@ -360,7 +361,6 @@ chdb_bgw_main(Datum main_arg) {
             );
         }
 
-        StreamingInProgress = true;
         PG_TRY();
         {
             CopyBuf = makeStringInfo();
@@ -403,7 +403,6 @@ chdb_bgw_main(Datum main_arg) {
             chdb_destroy_insert_stream(chDBInsertStream);
             chDBStreamingResult = NULL;
             chDBInsertStream    = NULL;
-            StreamingInProgress = false;
             PG_RE_THROW();
         }
         PG_END_TRY();
@@ -413,7 +412,6 @@ chdb_bgw_main(Datum main_arg) {
         chdb_destroy_insert_stream(chDBInsertStream);
         chDBStreamingResult = NULL;
         chDBInsertStream    = NULL;
-        StreamingInProgress = false;
     }
 
     /* Success! Close and commit. */
@@ -438,16 +436,9 @@ chdb_bgw_main(Datum main_arg) {
 
 /* Convenience constant function to append a parameter to a query. */
 /* Using quote_literal_cstr() to work around lack of parameter-supporting insert. */
-static bool isInsert = false;
 #define PARAM(format, name, val)                                                       \
     Assert(i + 1 <= CHDB_MAX_TABLEFUNC_ARGS);                                          \
-    if (isInsert) {                                                                    \
-        appendStringInfo(                                                              \
-            query, "%s%s", *format == ',' ? ", " : "", quote_literal_cstr(val)         \
-        );                                                                             \
-    } else {                                                                           \
-        appendStringInfoString(query, format);                                         \
-    }                                                                                  \
+    appendStringInfoString(query, format);                                             \
     names[i]  = name;                                                                  \
     values[i] = val;                                                                   \
     i++;
@@ -465,8 +456,6 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         ctx->extra.is_from ? "SELECT * FROM" : "INSERT INTO FUNCTION",
         table_function[ctx->extra.scheme]
     );
-
-    isInsert = !ctx->extra.is_from;
 
     /*
      * TODO: For streaming queries, the buffer is sized to fit one block of
@@ -771,7 +760,7 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
         avail = CopyBuf->len - CopyBuf->cursor;
     }
 
-    if (!StreamingInProgress || avail > 0) {
+    if (avail > 0) {
         return bytes_read;
     }
 
@@ -820,7 +809,6 @@ fetch_chdb_data(void* outbuf, int minread, int maxread) {
             if (chunk_length == 0) {
                 /* We're done. */
                 chdb_destroy_query_result(chDBChunkResult);
-                StreamingInProgress = false;
                 return bytes_read; /* End of stream. */
             }
             Assert(chunk_length <= INT_MAX);
@@ -1135,6 +1123,14 @@ format_ch_type(const char* typname, Form_pg_attribute attr) {
 static void
 setup_structure(chdbCopyContext* ctx, Relation rel, List* attnums) {
     if (ctx->structure[0] != '\0') {
+        /* Workaround for https://github.com/chdb-io/chdb-core/issues/158. */
+        char* cursor = ctx->structure;
+        while (*cursor != '\0') {
+            if (*cursor == '\n' || *cursor == '\r') {
+                *cursor = ' ';
+            }
+            cursor++;
+        }
         return;
     }
 

--- a/t/table-functions.pl
+++ b/t/table-functions.pl
@@ -34,7 +34,7 @@ subtest s3 => sub {
         $node, 'just TO url',
         qq{COPY stuff TO 's3://localhost:$port/bucket/prefix/file.csv'},
         qr/\QDB::Exception: Message: Access Denied/,
-        qr[\QINSERT INTO FUNCTION s3('s3://localhost\E:$port\Q/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
+        qr[\QINSERT INTO FUNCTION s3({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
@@ -150,7 +150,7 @@ subtest gcs => sub {
         $node, 'just TO url',
         qq{COPY stuff TO 'gcs://example.org/bucket/prefix/file.csv'},
         qr/chDB Error: Code: 499/,
-        qr[\QINSERT INTO FUNCTION gcs('https://example.org/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
+        qr[\QINSERT INTO FUNCTION gcs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
@@ -178,7 +178,7 @@ subtest http => sub {
     check_query(
         $node, 'just FROM url',
         qq{COPY stuff FROM 'http://example.org/path/file.csv'},
-        qr/\QHTTP status code: 404/,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
@@ -186,27 +186,27 @@ subtest http => sub {
         $node, 'just TO url',
         qq{COPY stuff TO 'http://example.org/path/file.csv'},
         qr/^$/, # XXX Why doesn't this fail?
-        qr[\QINSERT INTO FUNCTION url('http://example.org/path/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
+        qr[\QINSERT INTO FUNCTION url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
         $node, 'FROM format, structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (FORMAT 'TabSeparated', structure 'id Int32', timeout 500)},
-        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::NetException: Net Exception/,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "TabSeparated", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (structure 'id Int32', timeout 1500)},
-        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::NoMessageException: /,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=2, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO format',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (format 'CSV', timeout 100)},
-        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::NoMessageException: No message received/,
+        qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
         qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "CSV", structure: "id Int32 NULL" }],
     );
@@ -249,8 +249,8 @@ subtest azure => sub {
     check_query(
         $node, 'To azure with query',
         q{COPY stuff TO 'az://example.org/path/file.csv?x=y&abc=12'},
-        qr/Failed to receive table structure/, # XXX az just borked
-        qr[\QINSERT INTO FUNCTION azureBlobStorage('https://example.org?x=y&abc=12', 'path', 'file.csv', '', '', 'auto', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
+        qr/\QDB::Exception: std::out_of_range: map::at:  key not found./,
+        qr[\QINSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org?x=y&abc=12", container: "path", path: "file.csv", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Int32 NULL" }],
     );
     check_query(
@@ -331,7 +331,7 @@ subtest file => sub {
         $node, 'just TO file',
         qq{COPY stuff TO 'file://$dir/nonesuch.csv'},
         qr/^$/,
-        qr[\QINSERT INTO FUNCTION file('$dir/nonesuch.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr[\QINSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv", format: "auto", structure: "id Int32 NULL" }],
     );
 
@@ -350,8 +350,8 @@ subtest hdfs => sub {
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'hdfs://localhost:$port/bucket/prefix/file.csv'},
-        qr/Failed to receive table structure/, # XXX WTF
-        qr[\QINSERT INTO FUNCTION hdfs('hdfs://localhost:\E$port\Q/bucket/prefix/file.csv', 'auto', 'id Int32 NULL') SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
+        qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
+        qr[\QINSERT INTO FUNCTION hdfs({url:String}, {format:String}, {structure:String}) SETTINGS date_time_output_format='iso', engine_file_truncate_on_insert=1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Int32 NULL" }],
     );
     check_query(


### PR DESCRIPTION
Update to the newly-released chDB v26.5.1-rc.3 and adopt its improvements:

*   Remove the `StreamingInProgress` global boolean. EOF errors are now idempotent.
*   Use `chdb_stream_insert_with_params()` to start a streaming query and remove the `PARAM` hack that used literal strings (which could contain secrets!). Update `t/table-functions.pl` to match parameter placeholders rather than literal values in the query body for INSERT queries.
*   Regression: Strip newlines from a `structure` option, as it no longer parses a structure with newlines (chdb-io/chdb-core#158).

Also pass `-E` to `sudo` when installing chDB in the workflows so that `INSTALL_VERSION` remains set.