### PR TITLE
Add `http.sql` to test HTTP COPY requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
     name: 🐘 PostgreSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }}
     runs-on: ubuntu-${{ matrix.arch == 'amd64' && 'latest' || '24.04-arm' }}
     env: { chdb_version: v26.5.1-rc.3 }
+    services:
+      kv-rest:
+        image: ghcr.io/theory/kv-rest
+        ports: [80]
     steps:
       - name: Checkout the Repository
         uses: actions/checkout@v7
@@ -56,6 +60,7 @@ jobs:
         env:
           CLOUDSDK_AUTH_HMAC_KEY: ${{ secrets.gcp_hmac_key }}
           CLOUDSDK_AUTH_HMAC_SECRET: ${{ secrets.gcp_hmac_secret }}
+          PG_CHDB_HTTP_URL: http://localhost:${{ job.services.kv-rest.ports[80] }}
       - name: Show Diffs
         if: failure()
         run: find . -name regression.diffs -exec cat {} +

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -481,8 +481,7 @@ chdb_bgw_main(Datum main_arg) {
 static const char settings[] =
     "allow_experimental_nullable_tuple_type=1, "
     "date_time_output_format='iso', "
-    "output_format_json_quote_denormals=1, "
-    "engine_file_truncate_on_insert=1, " PGCH_NATIVE_SETTINGS;
+    "output_format_json_quote_denormals=1, " PGCH_NATIVE_SETTINGS;
 
 size_t
 make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values) {
@@ -540,7 +539,7 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         }
         appendStringInfo(
             query,
-            ") SETTINGS %s, s3_request_timeout_ms = %u, s3_truncate_on_insert = 1",
+            ") SETTINGS %s, s3_truncate_on_insert = 1, s3_request_timeout_ms = %u",
             settings,
             ctx->extra.timeout
         );
@@ -587,7 +586,7 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         PARAM(", {structure:String}", "structure", ctx->structure);
         appendStringInfo(
             query,
-            ") SETTINGS %s, azure_request_timeout_ms=%u",
+            ") SETTINGS %s, azure_truncate_on_insert = 1, azure_request_timeout_ms=%u",
             settings,
             ctx->extra.timeout
         );
@@ -605,7 +604,9 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         if (ctx->compression[0] != '\0') {
             PARAM(", {compression:String}", "compression", ctx->compression);
         }
-        appendStringInfo(query, ") SETTINGS %s", settings);
+        appendStringInfo(
+            query, ") SETTINGS %s, engine_file_truncate_on_insert=1", settings
+        );
         break;
     case hdfs_scheme:
         /* https://clickhouse.com/docs/sql-reference/table-functions/hdfs#syntax */
@@ -616,7 +617,7 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
         /* Append remaining arguments and settings. */
         PARAM(", {format:String}", "format", ctx->format[0] ? ctx->format : "auto");
         PARAM(", {structure:String}", "structure", ctx->structure);
-        appendStringInfo(query, ") SETTINGS %s", settings);
+        appendStringInfo(query, ") SETTINGS %s, hdfs_truncate_on_insert = 1", settings);
         break;
     default:
         elog(ERROR, "unsupported URL scheme %d", ctx->extra.scheme);

--- a/t/table-functions.pl
+++ b/t/table-functions.pl
@@ -27,14 +27,14 @@ subtest s3 => sub {
         $node, 'just FROM url',
         qq{COPY stuff FROM 's3://localhost:$port/bucket/prefix/file.csv'},
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 30000],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 's3://localhost:$port/bucket/prefix/file.csv'},
         qr/\QDB::Exception: Message: Access Denied/,
-        qr[\QINSERT INTO FUNCTION s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 30000],
+        qr[\QINSERT INTO FUNCTION s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
@@ -51,7 +51,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", session_token: "big fat token", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
     check_query(
@@ -67,7 +67,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {session_token:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "", session_token: "some token", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
     check_query(
@@ -82,7 +82,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", access_key: "key", access_secret: "", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
     check_query(
@@ -95,7 +95,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "id Int64" }],
     );
     check_query(
@@ -108,7 +108,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "parquet", structure: "id Nullable(Int32)", compression: "snappy" }],
     );
     check_query(
@@ -120,7 +120,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)", compression: "snappy" }],
     );
     check_query(
@@ -132,7 +132,7 @@ subtest s3 => sub {
             )
         },
         qr/\QHTTP response code: 403/,
-        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 100],
+        qr[\QSELECT * FROM s3({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 100],
         qr[\Q{ url: "s3://localhost:\E$port\Q/bucket/prefix/file.csv", format: "tsv", structure: "id Nullable(Int32)" }],
     );
 };
@@ -143,14 +143,14 @@ subtest gcs => sub {
         $node, 'just FROM url',
         qq{COPY stuff FROM 'gcs://example.org/bucket/prefix/file.csv'},
         qr/\QHTTP response code: 404/,
-        qr[\QSELECT * FROM gcs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 30000],
+        qr[\QSELECT * FROM gcs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'gcs://example.org/bucket/prefix/file.csv'},
         qr/chDB Error: Code: 499/,
-        qr[\QINSERT INTO FUNCTION gcs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 30000],
+        qr[\QINSERT INTO FUNCTION gcs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 30000],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
@@ -167,7 +167,7 @@ subtest gcs => sub {
             )
         },
         qr/\QHTTP response code: 404/,
-        qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_request_timeout_ms = 0],
+        qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
         qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
 };
@@ -179,35 +179,35 @@ subtest http => sub {
         $node, 'just FROM url',
         qq{COPY stuff FROM 'http://example.org/path/file.csv'},
         qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
-        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=30, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'just TO url',
         qq{COPY stuff TO 'http://example.org/path/file.csv'},
         qr/^$/, # XXX Why doesn't this fail?
-        qr[\QINSERT INTO FUNCTION url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=30, http_max_tries=1],
+        qr[\QINSERT INTO FUNCTION url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=30, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'FROM format, structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (FORMAT 'TabSeparated', structure 'id Int32', timeout 500)},
         qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
-        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=1, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "TabSeparated", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO structure, round up timeout',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (structure 'id Int32', timeout 1500)},
         qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
-        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=2, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=2, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "auto", structure: "id Int32" }],
     );
     check_query(
         $node, 'TO format',
         qq{COPY stuff FROM 'http://example.org/path/file.csv' (format 'CSV', timeout 100)},
         qr/\QHTTP status code: 404\E|\QDB::Exception: Poco::Net::/,
-        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=1, http_max_tries=1],
+        qr[\QSELECT * FROM url({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, http_connection_timeout=1, http_max_tries=1],
         qr[\Q{ url: "http://example.org/path/file.csv", format: "CSV", structure: "id Nullable(Int32)" }],
     );
 };
@@ -243,21 +243,21 @@ subtest azure => sub {
         $node, 'just FROM azure',
         q{COPY stuff FROM 'az://example.org/path/file.csv'},
         qr/Azure::Storage::StorageException: 404 Not Found/,
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "path", path: "file.csv", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'To azure with query',
         q{COPY stuff TO 'az://example.org/path/file.csv?x=y&abc=12'},
         qr/\QDB::Exception: std::out_of_range: map::at:  key not found./,
-        qr[\QINSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=30000],
+        qr[\QINSERT INTO FUNCTION azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org?x=y&abc=12", container: "path", path: "file.csv", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'FROM azure with no path',
         q{COPY stuff FROM 'az://example.org/container'},
         qr/The data format cannot be detected by the contents/, # XXX az just borked
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "container", path: "", account_name: "", account_key: "", format: "auto", compression: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
@@ -274,7 +274,7 @@ subtest azure => sub {
             )
         },
         qr/Unexpected end of Base64 encoded string/, # XXX az just borked
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=200],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=200],
         qr[\Q{ url: "https://acc.example.org", container: "xyz", path: "yep.csv", account_name: "ac_name", account_key: "ac_key", format: "tsv", compression: "lz4", structure: "id Int32" }],
     );
 
@@ -282,7 +282,7 @@ subtest azure => sub {
         $node, 'FROM abfs with compression & structure',
         q{COPY stuff FROM 'abfs://container@account/xyz/yep.csv' (access_key 'ac-key', compression 'snappy', structure 'x String')},
         qr/403 The specified account is disabled/,
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://account.blob.core.windows.net", container: "container", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "snappy", structure: "x String" }],
     );
 
@@ -290,7 +290,7 @@ subtest azure => sub {
         $node, 'FROM abfss host with structure',
         q{COPY stuff FROM 'abfss://hi@example.org/xyz/yep.csv' (access_key 'ac-key', structure 'x String')},
         qr/Azure::Storage::StorageException: 404 Not Found/,
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "hi", path: "xyz/yep.csv", account_name: "ac-key", account_key: "", format: "auto", compression: "auto", structure: "x String" }],
     );
 
@@ -298,7 +298,7 @@ subtest azure => sub {
         $node, 'FROM no-path abfs with format only',
         q{COPY stuff FROM 'abfs://slick@example.org' (format 'TSV')},
         qr/Azure::Storage::StorageException: 404 Not Found/,
-        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_request_timeout_ms=30000],
+        qr[\QSELECT * FROM azureBlobStorage({url:String}, {container:String}, {path:String}, {account_name:String}, {account_key:String}, {format:String}, {compression:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, azure_truncate_on_insert = 1, azure_request_timeout_ms=30000],
         qr[\Q{ url: "https://example.org", container: "slick", path: "", account_name: "", account_key: "", format: "TSV", compression: "auto", structure: "id Nullable(Int32)" }],
     );
 };
@@ -315,7 +315,7 @@ subtest file => sub {
         $node, 'just FROM file',
         qq{COPY stuff FROM 'file://$dir/nonesuch.csv'},
         qr/nonesuch.csv doesn't exist/,
-        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
 
@@ -323,7 +323,7 @@ subtest file => sub {
         $node, 'all options',
         qq{COPY stuff FROM 'file://$dir/nonesuch.csv' (compression 'lz4', structure 'z Int8', format 'tsv')},
         qr/nonesuch.csv doesn't exist/,
-        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QSELECT * FROM file({path:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv", format: "tsv", structure: "z Int8", compression: "lz4" }],
     );
 
@@ -331,7 +331,7 @@ subtest file => sub {
         $node, 'just TO file',
         qq{COPY stuff TO 'file://$dir/nonesuch.csv'},
         qr/^$/,
-        qr[\QINSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QINSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1],
         qr[\Q{ path: "$dir/nonesuch.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
 
@@ -343,7 +343,7 @@ subtest hdfs => sub {
         $node, 'just FROM url',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv'},
         qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, hdfs_truncate_on_insert = 1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
 
@@ -351,28 +351,28 @@ subtest hdfs => sub {
         $node, 'just TO url',
         qq{COPY stuff TO 'hdfs://localhost:$port/bucket/prefix/file.csv'},
         qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
-        qr[\QINSERT INTO FUNCTION hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QINSERT INTO FUNCTION hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, hdfs_truncate_on_insert = 1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'FROM url with format and structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (FORMAT 'TSV', STRUCTURE 'a Int8')},
         qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, hdfs_truncate_on_insert = 1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TSV", structure: "a Int8" }],
     );
     check_query(
         $node, 'FROM url with structure',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (STRUCTURE 'a UInt8')},
         qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, hdfs_truncate_on_insert = 1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "auto", structure: "a UInt8" }],
     );
     check_query(
         $node, 'FROM url with format',
         qq{COPY stuff FROM 'hdfs://localhost:$port/bucket/prefix/file.csv' (format 'TabSeparated')},
         qr/\QDB::Exception: Unable to connect to HDFS\E|\QUnknown table function hdfs/, # XXX WTF
-        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1],
+        qr[\QSELECT * FROM hdfs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, hdfs_truncate_on_insert = 1],
         qr[\Q{ url: "hdfs://localhost:\E$port\Q/bucket/prefix/file.csv", format: "TabSeparated", structure: "id Nullable(Int32)" }],
     );
 };

--- a/test/expected/datetimes.out
+++ b/test/expected/datetimes.out
@@ -231,12 +231,12 @@ f: ORC
 t: Avro
 psql:test/utils/round-trip-formats.sql:402: ERROR:  chdb: error finishing chDB query
 DETAIL:  chDB Error: Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW)
-CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1
+CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
 psql:test/utils/round-trip-formats.sql:402: STATEMENT:  COPY "datetime_arrays" TO 'file:///tmp/datetimes.tmp' (format 'Protobuf');
 f: Protobuf
 psql:test/utils/round-trip-formats.sql:421: ERROR:  chdb: error finishing chDB query
 DETAIL:  chDB Error: Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW)
-CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, engine_file_truncate_on_insert=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1
+CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
 psql:test/utils/round-trip-formats.sql:421: STATEMENT:  COPY "datetime_arrays" TO 'file:///tmp/datetimes.tmp' (format 'ProtobufList');
 f: ProtobufList
 t: MsgPack

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -1,0 +1,26 @@
+\set ECHO errors
+LOAD 'chdb';
+-- Create some random data to copy.
+CREATE TABLE url_things (
+    id       INT  PRIMARY KEY,
+    name     TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+INSERT INTO url_things
+VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+;
+-- Copy the data to S3.
+COPY url_things TO :'url';
+-- Second copy should not fail.
+COPY url_things TO :'url';
+-- Copy it back.
+CREATE TABLE url_things2 (LIKE url_things INCLUDING ALL);
+COPY url_things2 FROM :'url';
+-- Make sure they're the same.
+WITH x AS (
+    SELECT * FROM url_things EXCEPT ALL SELECT * FROM url_things2
+) SELECT COUNT(*) = 0 AS same FROM x \gset
+\set ECHO errors
+Table contents the same

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -1,0 +1,2 @@
+\set ECHO errors
+SKIP: No URL found in $PG_CHDB_HTTP_URL

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -1,0 +1,58 @@
+\set ECHO errors
+-- Get base URL from the environment.
+\set base_url ''
+\getenv base_url PG_CHDB_HTTP_URL
+SELECT :'base_url' = '' AS no_url \gset
+
+-- Bail if no URL.
+\if :no_url
+\echo 'SKIP: No URL found in $PG_CHDB_HTTP_URL'
+\quit
+\endif
+
+-- Create unique URL path to avoid conflicts between concurrent execution.
+SELECT (random() * 100000)::int AS rand \gset
+\set arch ''
+\getenv arch RUNNER_ARCH
+\set url :base_url /ci/:SERVER_VERSION_NUM - :arch - :rand /test.csv
+\set ECHO all
+
+LOAD 'chdb';
+
+-- Create some random data to copy.
+CREATE TABLE url_things (
+    id       INT  PRIMARY KEY,
+    name     TEXT NOT NULL,
+    quantity INT NOT NULL
+);
+
+INSERT INTO url_things
+VALUES ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+     , ((random() * 10000)::int, format('thing-%s', (random() * 100)::int), (random() * 1000)::int)
+;
+
+-- Copy the data to S3.
+COPY url_things TO :'url';
+
+-- Second copy should not fail.
+COPY url_things TO :'url';
+
+-- Copy it back.
+CREATE TABLE url_things2 (LIKE url_things INCLUDING ALL);
+COPY url_things2 FROM :'url';
+
+-- Make sure they're the same.
+WITH x AS (
+    SELECT * FROM url_things EXCEPT ALL SELECT * FROM url_things2
+) SELECT COUNT(*) = 0 AS same FROM x \gset
+
+\set ECHO errors
+\if :same
+\echo 'Table contents the same'
+\else
+\echo 'Table contents differ; want:'
+SELECT * FROM url_things;
+\echo 'But got'
+SELECT * FROM url_things2;
+\endif


### PR DESCRIPTION
Set `PG_CHDB_HTTP_URL` to the base URL; skips the test it not set. The workflow uses a very silly little service I wrote just for this purpose.

Remove the `engine_file_truncate_on_insert` except for file requests and add azure_request_timeout_ms=1` to azure and `hdfs_truncate_on_insert=1` to HDFS requests.