### PR TITLE
Improve error handling

### DIFF
--- a/src/bgw/native.c
+++ b/src/bgw/native.c
@@ -46,6 +46,7 @@
 #include "pg-clickhouse-encode.h"
 
 #include "native.h"
+#include "worker.h"
 
 /*
  * Bytes to accumulate before cutting a block. ClickHouse coalesces small
@@ -116,7 +117,7 @@ send_block(pgch_writer* w, pgch_buf* buf, chdb_insert_stream stream) {
     if (chdb_stream_append(stream, buf->data, buf->len) != CHDBSuccess) {
         const char* error = chdb_stream_insert_error(stream);
 
-        error = chdb_trim_error(pstrdup(error ? error : "unknown error"));
+        error = error ? chdb_capture_error(error) : "unknown error";
         chdb_stream_cancel_insert(stream);
         ereport(
             ERROR,
@@ -232,36 +233,26 @@ free_native_chunks(void* arg) {
 }
 
 /*
- * chDB repeats a request ID per attempt in storage errors, appends a stack
- * trace to others, and ends every message with its own version. None belongs
- * in error message.
+ * Copy error minus Request ID before freeing chDB result. Result is valid
+ * until next call to chdb_capture_error.
  */
 char*
-chdb_trim_error(char* error) {
-    char* id  = strstr(error, "Request ID:");
-    char* eol = id ? strchr(id, '\n') : NULL;
+chdb_capture_error(const char* error) {
+    static char buf[CHDB_ERROR_QUEUE_SIZE / 4];
+    const char* id  = strstr(error, "Request ID:");
+    const char* eol = id ? strchr(id, '\n') : NULL;
+    size_t len      = 0;
 
     if (eol) {
-        memmove(id, eol + 1, strlen(eol + 1) + 1);
+        len = Min((size_t)(id - error), sizeof(buf) - 1);
+        memcpy(buf, error, len);
+        error = eol + 1;
     }
-    char* trace = strstr(error, ", Stack trace (when copying this message");
-    if (trace) {
-        *trace = '\0';
-    } else {
-        char* version = NULL;
-        for (char* pos = error; (pos = strstr(pos, " (version ")); pos++) {
-            version = pos;
-        }
-        if (version) {
-            char* close = strchr(version, ')');
+    size_t rest = Min(strlen(error), sizeof(buf) - 1 - len);
 
-            if (close && close[1] == '\0') {
-                *version = '\0';
-            }
-        }
-    }
-
-    return error;
+    memcpy(buf + len, error, rest);
+    buf[len + rest] = '\0';
+    return buf;
 }
 
 /*
@@ -279,13 +270,8 @@ next_chunk(void* ud, const void** p, size_t* n, char** error) {
     }
 
     chunks->chunk = chdb_stream_fetch_result(chunks->conn, chunks->result);
-    if (!chunks->chunk) {
-        chdb_stream_cancel_query(chunks->conn, chunks->result);
-        *error = "streaming fetch failed";
-        return false;
-    }
     if ((err = chdb_result_error(chunks->chunk))) {
-        *error = chdb_trim_error(pstrdup(err));
+        *error = chdb_capture_error(err);
         chdb_destroy_query_result(chunks->chunk);
         chunks->chunk = NULL;
         return false;

--- a/src/bgw/native.h
+++ b/src/bgw/native.h
@@ -6,9 +6,9 @@
 
 #include "utils/relcache.h"
 
-/* Strips the request ID and stack trace chDB pads an error with, in place. */
+/* Copy and clean up a chDB error, truncating it if necessary. */
 extern char*
-chdb_trim_error(char* error);
+chdb_capture_error(const char* error);
 
 /*
  * Scans the `attnums` columns of `rel` into `stream` as Native blocks carrying

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -21,6 +21,7 @@
 #include "nodes/nodes.h"
 #include "storage/ipc.h"
 #include "storage/shm_toc.h"
+#include "tcop/tcopprot.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
@@ -59,6 +60,13 @@ free_chdb_resources(void* arg) {
     chdbResources* resources = arg;
 
     if (resources->result) {
+        /*
+         * Cancel the query to release stream state after an interrupted copy.
+         * Cancellation has no effect after the stream ends.
+         */
+        if (resources->conn) {
+            chdb_stream_cancel_query(*resources->conn, resources->result);
+        }
         chdb_destroy_query_result(resources->result);
         resources->result = NULL;
     }
@@ -282,10 +290,13 @@ chdb_bgw_main(Datum main_arg) {
     MemoryContextRegisterResetCallback(CurrentMemoryContext, &resources->cleanup);
 
     /*
-     * Connect to chDB. It uses a temporary directory that it cleans up upon
-     * exit.
+     * Connect to chDB. It uses a temporary directory and removes it on exit.
+     * Disable ClickHouse signal handlers to preserve Postgres behavior, then
+     * restore the Postgres SIGFPE handler because disabling them resets it.
      */
+    chdb_set_signal_handlers_enabled(0);
     resources->conn = chdb_connect(1, (char*[]){ "chdb" });
+    pqsignal(SIGFPE, FloatExceptionHandler);
 
     if (!resources->conn) {
         ereport(
@@ -360,42 +371,20 @@ chdb_bgw_main(Datum main_arg) {
             param_count
         );
 
-        if (!resources->result) {
-            ereport(
-                ERROR,
-                errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
-                errmsg("chdb: error executing chDB query"),
-                errcontext("query: %s", ch_query.data)
-            );
-        }
-
         /* Check for errors. */
         if ((error = chdb_result_error(resources->result))) {
-            error = chdb_trim_error(pstrdup(error));
             ereport(
                 ERROR,
                 errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
                 errmsg("chdb: error executing chDB query"),
-                errdetail("%s", error),
+                errdetail("%s", chdb_capture_error(error)),
                 errcontext("query: %s", ch_query.data)
             );
         }
 
         /* Decode the blocks chDB streams back and insert their rows. */
-        PG_TRY();
-        {
-            num_rows =
-                chdb_native_receive(rel, attnums, *resources->conn, resources->result);
-        }
-        PG_CATCH();
-        {
-            /* Cleanup streaming query. */
-            table_close(rel, RowExclusiveLock);
-            PopActiveSnapshot();
-            AbortCurrentTransaction();
-            PG_RE_THROW();
-        }
-        PG_END_TRY();
+        num_rows =
+            chdb_native_receive(rel, attnums, *resources->conn, resources->result);
     } else {
         /* Start the streaming insert. */
         resources->insert = chdb_stream_insert_with_params(
@@ -409,42 +398,28 @@ chdb_bgw_main(Datum main_arg) {
 
         /* Check for errors. */
         if ((error = chdb_stream_insert_error(resources->insert))) {
-            error = chdb_trim_error(pstrdup(error));
             ereport(
                 ERROR,
                 errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
                 errmsg("chdb: unable to execute query"),
-                errdetail("chDB Error: %s", error),
+                errdetail("chDB Error: %s", chdb_capture_error(error)),
                 errcontext("query: %s", ch_query.data)
             );
         }
 
-        PG_TRY();
-        {
-            num_rows =
-                chdb_native_send(rel, ctx->structure, attnums, resources->insert);
+        num_rows = chdb_native_send(rel, ctx->structure, attnums, resources->insert);
 
-            /* Tell chDB the insert is done. */
-            resources->result = chdb_stream_done(resources->insert);
-            if ((error = chdb_result_error(resources->result))) {
-                ereport(
-                    ERROR,
-                    errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
-                    errmsg("chdb: error finishing chDB query"),
-                    errdetail("chDB Error: %s", chdb_trim_error(pstrdup(error))),
-                    errcontext("query: %s", ch_query.data)
-                );
-            }
+        /* Tell chDB the insert is done. */
+        resources->result = chdb_stream_done(resources->insert);
+        if ((error = chdb_result_error(resources->result))) {
+            ereport(
+                ERROR,
+                errcode(ERRCODE_EXTERNAL_ROUTINE_EXCEPTION),
+                errmsg("chdb: error finishing chDB query"),
+                errdetail("chDB Error: %s", chdb_capture_error(error)),
+                errcontext("query: %s", ch_query.data)
+            );
         }
-        PG_CATCH();
-        {
-            /* Cleanup streaming insert. */
-            table_close(rel, AccessShareLock);
-            PopActiveSnapshot();
-            AbortCurrentTransaction();
-            PG_RE_THROW();
-        }
-        PG_END_TRY();
     }
 
     /* Success! Close and commit. */

--- a/src/hook.c
+++ b/src/hook.c
@@ -61,11 +61,7 @@ open_copy_relation(CopyStmt* copy);
 static void
 contextualize_options(chdbCopyContext* ctx, List* options);
 void
-ProcessMessages(
-    shm_mq_handle* queue,
-    QueryCompletion* qc,
-    BackgroundWorkerHandle* handle
-);
+ProcessMessages(shm_mq_handle* queue, QueryCompletion* qc);
 
 /*
  * InitializeUtilityHook hooks chDBProcessUtilityHook into the process utility
@@ -418,15 +414,6 @@ LaunchWorker(chdbCopyContext* ctx, QueryCompletion* qc) {
     pid_t pid;
     BgwHandleStatus status = WaitForBackgroundWorkerStartup(handle, &pid);
 
-    if (status == BGWH_STOPPED) {
-        dsm_detach(seg);
-        ereport(
-            ERROR,
-            (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-             errmsg("chdb: could not start background process"),
-             errhint("More details may be available in the server log."))
-        );
-    }
     if (status == BGWH_POSTMASTER_DIED) {
         ereport(
             ERROR,
@@ -435,11 +422,16 @@ LaunchWorker(chdbCopyContext* ctx, QueryCompletion* qc) {
              errhint("Kill all remaining database processes and restart the database."))
         );
     }
-    Assert(status == BGWH_STARTED);
+
+    /*
+     * BGWH_STOPPED also covers a worker that already ran to completion, with
+     * its messages waiting in the queue, so fall through to drain it.
+     */
+    Assert(status == BGWH_STARTED || status == BGWH_STOPPED);
 
     /* Wait for it to finish. */
     PG_TRY();
-    { ProcessMessages(mqh, qc, handle); }
+    { ProcessMessages(mqh, qc); }
     PG_CATCH();
     {
         dsm_detach(seg);
@@ -459,11 +451,7 @@ LaunchWorker(chdbCopyContext* ctx, QueryCompletion* qc) {
  * queue has been drained.
  */
 void
-ProcessMessages(
-    shm_mq_handle* queue,
-    QueryCompletion* qc,
-    BackgroundWorkerHandle* handle
-) {
+ProcessMessages(shm_mq_handle* queue, QueryCompletion* qc) {
     Size msg_len;
     void* data;
     StringInfoData msg;
@@ -472,23 +460,17 @@ ProcessMessages(
     for (;;) {
         CHECK_FOR_INTERRUPTS();
 
-        /* Check on the health of the background worker. */
-        pid_t pid;
-        BgwHandleStatus status = GetBackgroundWorkerPid(handle, &pid);
-        if (status == BGWH_STOPPED || status == BGWH_POSTMASTER_DIED) {
-            ereport(
-                ERROR,
-                errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-                errmsg("chdb: the background worker died")
-            );
-        }
-
+        /*
+         * shm_mq_receive drains fully written messages before SHM_MQ_DETACHED,
+         * and detects a worker that dies before attaching as sender.
+         * Detach without PqMsg_Terminate means the worker died.
+         */
         shm_mq_result res = shm_mq_receive(queue, &msg_len, &data, false);
         if (res != SHM_MQ_SUCCESS) {
             ereport(
                 ERROR,
                 errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-                errmsg("chdb: lost connection to chdb worker")
+                errmsg("chdb: the background worker died")
             );
         }
 

--- a/test/expected/datetimes.out
+++ b/test/expected/datetimes.out
@@ -230,12 +230,12 @@ psql:test/utils/round-trip-formats.sql:376: STATEMENT:  COPY "datetime_arrays2" 
 f: ORC
 t: Avro
 psql:test/utils/round-trip-formats.sql:402: ERROR:  chdb: error finishing chDB query
-DETAIL:  chDB Error: Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW)
+DETAIL:  chDB Error: Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW) (version 26.5.1.1)
 CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
 psql:test/utils/round-trip-formats.sql:402: STATEMENT:  COPY "datetime_arrays" TO 'file:///tmp/datetimes.tmp' (format 'Protobuf');
 f: Protobuf
 psql:test/utils/round-trip-formats.sql:421: ERROR:  chdb: error finishing chDB query
-DETAIL:  chDB Error: Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW)
+DETAIL:  chDB Error: Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW) (version 26.5.1.1)
 CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
 psql:test/utils/round-trip-formats.sql:421: STATEMENT:  COPY "datetime_arrays" TO 'file:///tmp/datetimes.tmp' (format 'ProtobufList');
 f: ProtobufList


### PR DESCRIPTION
Capture errors into 2KB static buffer to avoid pstrdup errors in error handling path

Don't NULL check chdb_stream_fetch_result, it never returns NULL

Cancel stream before destroying result, avoids leaving that to transaction abort (destroy alone only calls C++ delete)

Remove PG_TRY/PG_CATCH when an enclosing PG_TRY/PG_CATCH already exists

Prevent chdb blocking signal handling