### PR TITLE
Expand docs, list limitations, add more more URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,32 @@ chdb Postgres Extension
 
 This library contains a single PostgreSQL extension, `chdb`, which provides a
 background worker to execute [chDB] queries. It currently only supports [COPY]
-to a URL.
+to or from an S3, GCS, Azure Blob, file, or http URL. This example loads
+records from multiple CSV files on S3 in a single [COPY] command:
+
+```sql
+CREATE TABLE times (
+    id     INT NOT NULL,
+    months INT NOT NULL,
+    days   INT NOT NULL
+);
+
+COPY times FROM 's3://datasets-documentation/my-test-bucket-768/{some,another}_prefix/some_file_{1..3}.csv';
+```
+
+Dependencies
+------------
+
+The `chdb` extension requires PostgreSQL 16 or higher and the [chDB] library
+v26.5.1 or greater. The simplest way to install it is via the [lib.chdb.io]
+shell script:
+
+```sh
+curl -sL https://lib.chdb.io | bash
+```
+
+Installation
+------------
 
 To build chdb, just do this:
 
@@ -52,8 +77,8 @@ If you encounter an error such as:
 worker.c:1:10: fatal error: 'chdb.h' file not found
 ```
 
-You either need to install [chDB] or tell the compiler where to find it.
-If, for example, you installed it via the [lib.chdb.io] shell script, point to
+You either need to install [chDB] or tell the compiler where to find it. If,
+for example, you installed it via the [lib.chdb.io] shell script, point to
 `/usr/local`:
 
 ``` sh
@@ -89,8 +114,8 @@ extension_control_path = '/usr/local/extras/postgresql/share:$system'
 dynamic_library_path   = '/usr/local/extras/postgresql/lib:$libdir'
 ```
 
-Once chdb is installed, you can add it to a database by connecting to a
-database as a super user and running:
+Once the chdb extension is installed, you can add it to a database by
+connecting as a super user and running:
 
 ``` sql
 CREATE EXTENSION chdb;
@@ -103,11 +128,6 @@ specific schema, use the `SCHEMA` clause to specify the schema, like so:
 CREATE SCHEMA chdb;
 CREATE EXTENSION chdb SCHEMA chdb;
 ```
-
-Dependencies
------------
-
-The `chdb` extension requires PostgreSQL 16 or higher and the [chDB] library.
 
 Author
 ------

--- a/doc/chdb.md
+++ b/doc/chdb.md
@@ -9,26 +9,36 @@ CREATE EXTENSION
 
 # LOAD 'chdb';
 LOAD
+
+# CREATE TABLE times (
+    id     INT NOT NULL,
+    months INT NOT NULL,
+    days   INT NOT NULL
+);
+CREATE TABLE
+
+# COPY times FROM 's3://datasets-documentation/my-test-bucket-768/{some,another}_prefix/some_file_{1..3}.csv';
+COPY 16
 ```
 
 ## Description
 
 This library contains a single PostgreSQL extension, `chdb`, which provides a
 background worker to execute [chDB] queries. It currently only supports [COPY]
-to a URL.
+to or from a URL.
 
 ## Loading
 
 Load the chdb extension in one of the following ways as a super user. Use
 whichever makes the most sense for your use case:
 
-*   Explicitly via the [LOAD] command:
+*   Explicitly via the [LOAD] command; lasts for the duration of a session:
 
     ```sql
     LOAD 'chdb';
     ```
 
-*   Implicitly by calling [pgchdb_version()]:
+*   Implicitly by calling [pgchdb_version()]; lasts for the duration of a session:
 
     ```sql
     SELECT pgchdb_version();
@@ -66,16 +76,17 @@ whichever makes the most sense for your use case:
     ```
 
 > [!WARNING]
-> Be aware that loading the chdb extension allows users to `COPY` data to and
-> from files on the Postgres server, as well as to cloud storage.
+> Be aware that loading the chdb extension allows users in the
+> `pg_read_server_files` or `pg_write_server_files` roles to `COPY` data to
+> and from files on the Postgres server, as well as cloud storage.
 
 ## COPY Overloading
 
 On [loading](#loading), the chdb extension library wires itself into the
-Postgres [COPY] command to allow copying data `TO` or `FROM` all of the [data
-formats provided by chDB][formats], and stored in local files, [AWS S3]
-buckets, [Google Cloud Storage], and more. To load a table from a CSV file in
-S3, for example, create the table then call `COPY` with an `s3://` URL:
+Postgres [COPY] command to copy data `TO` or `FROM` any of the supported [data
+formats provided by chDB][formats] in local files, [AWS S3] buckets, [Google
+Cloud Storage], and more. To load a table from a CSV file in S3, for example,
+create the table then call `COPY` with an `s3://` URL:
 
 ```sql
 CREATE TABLE times (
@@ -90,7 +101,7 @@ COPY times FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some
 ### Background Worker
 
 When the chdb extension library detects a `COPY` command it can handle, it
-starts a [background worker] to handle it. The background worker keeps the
+starts a [background worker] to do so. The background worker keeps the
 resource consumption of [chDB] separate from the main Postgres process, an
 advantage for an occasionally-used workflow such as loading data from a data
 lake.
@@ -113,17 +124,10 @@ ALTER SYSTEM SET max_worker_processes = 12;
 ### Privileges
 
 A chdb `COPY` requires the same privileges as the [COPY] it replaces: `SELECT`
-on the relation or on every copied column for `COPY TO`, and `INSERT` for `COPY
-FROM`. A `file://` URL reads or writes a file on the server, so also requires
-membership in `pg_read_server_files` or `pg_write_server_files`. `COPY FROM`
-requires a read-write transaction.
-
-The chdb extension rejects two cases it cannot copy faithfully:
-
-*   Relations with [row-level security] policies that apply to the copying
-    role. Postgres applies such policies by rewriting `COPY TO` into a query,
-    which the chdb extension does not support.
-*   Temporary relations, which only the session that created them can read.
+on the relation or on every copied column for `COPY TO`, and `INSERT` for
+`COPY FROM`. A `file://` URL reads or writes a file on the server, so also
+requires membership in `pg_read_server_files` or `pg_write_server_files`.
+`COPY FROM` requires a read-write transaction.
 
 ### URL Schemes
 
@@ -146,10 +150,11 @@ The format of URLs varies by the target.
 #### File
 
 Must be an absolute path on the Postgres server. A relative path results in an
-error. The Postgres server user must have read or write access to the file, as
-appropriate. For `COPY TO`, if the path does not exist, the chdb extension
-will create any missing parent directories; it must have file system
-permission to do so. Example:
+error. The Postgres user must be a member of the `pg_read_server_files` or
+`pg_write_server_files` role, as appropriate. The Postgres system user must
+have read or write access to the file, as appropriate. For `COPY TO`, if the
+path does not exist, the chdb extension will create any missing parent
+directories; it must have file system permission to do so. Example:
 
 ```
 file:///tmp/users.parquet
@@ -166,18 +171,30 @@ https://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/som
 
 #### S3
 
-S3 URLs take this form:
+S3 URLs may take the form of an S3 URI
 
 ```
 s3://{bucket}/{path}
 ```
 
-GCS URLs take this form:
+Or of an object URL:
+
+```
+s3://{bucket}.{region}.amazonaws.com/{path}
+```
 
 #### GCS
 
+GCS URLs take the form of a public URL:
+
 ```
-gcs://storage.googleapis.com/{bucket}/{path}
+gs://storage.googleapis.com/{bucket}/{path}
+```
+
+Or a Cloud Storage URI, which chdb converts to a public URL:
+
+```
+gs://{bucket}/{path}
 ```
 
 #### Azure Blob Storage
@@ -196,25 +213,34 @@ az://{host}/{container}/{blob}
 
 #### Azure ABFS
 
-Must use this format:
+ABFS URLs must use this format:
 
 ```
 abfs://{container}@{account}.dfs.core.windows.net/{blob}
 ```
 
+#### HDFS URLS
+
+HDFS URLs may use typical HTTP-style URLs with an optional port:
+
+```
+hdfs://{host}/{path}
+hdfs://{host}:{port}/{path}
+```
+
 ### Path Wildcards
 
 URL Paths may contain globs in `COPY FROM` commands. Files must match the
-whole path pattern, not only the suffix or prefix. There is one exception that
-if the path refers to an existing directory and does not use globs, a `*` will
-be implicitly added to the path so all the files in the directory are
-selected.
+whole path pattern, not only the suffix or prefix. The one exception: when
+path refers to an existing directory and does not use globs, a `*` will be
+implicitly added to the path to select all of the files in the directory.
+
+The supported wildcards:
 
 *   `*`: Arbitrarily match many characters except `/`, including the empty string.
 *   `?`: Match an arbitrary single character.
-*   `{some_string,another_string,yet_another_one}`: Substitute any of strings
-    "some_string", "another_string", and "yet_another_one". The strings may
-    contain `/`.
+*   `{groucho,harpo,chico}`: Substitute any of strings "groucho", "harpo", and
+    "chico". The strings may contain `/`.
 *   `{N..M}`: Match any number `>= N` and `<= M`.
 *   `**`: Recursively match all files in a directory.
 
@@ -255,29 +281,34 @@ at the end of the URL.
 
 #### `structure`
 
-The [chDB] data structure to use for the data. Consists of a list of column
-names and [ClickHouse data types] and modifiers. If omitted, the chdb
-extension maps the Postgres data types to generally-appropriate ClickHouse
-types; see [Data Types](#data-types) for details. If set to `auto`, chDB
-attempts to infer the types.
+The [chDB] data structure for a row. Consists of a list of column names and
+[ClickHouse data types] and modifiers. If omitted, the chdb extension maps the
+Postgres data types to generally-appropriate ClickHouse types; see [Data
+Types](#data-types) for details. If set to `auto`, chDB attempts to infer the
+types.
 
 Example:
 
 ```sql
 COPY users TO 'file:///tmp/users.parquet' (
-    structure 'id Int64, name String, age UInt8, attributes JSON'
+    structure 'id Int64, name String, age Nullable(UInt8), attributes JSON'
 );
 ```
 
 #### `access_key` and `access_secret`
 
 Long-term credentials for the AWS account user to authenticate requests.
-Supported by S3, GCS, Azure, and HDFS URLs.
+
+*   **S3:** An AWS [access key ID and access secret], often defined with the
+    environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+*   **GCS:** A GCP [HMAC key and secret]
+*   **Azure:** An Azure Storage account name and [access key]
 
 #### `session_token`
 
-Session token to use with the `access_key` and `access_secret`. Supported
-by S3 URLs.
+AWS session token to use with the `access_key` and `access_secret`, often
+defined by the environment variable `AWS_SESSION_TOKEN`. Used only for S3
+URLs.
 
 #### `compression`
 
@@ -301,7 +332,7 @@ Defaults to `30000` (30s).
 In the absence of an explicit [structure](#structure) option, the chDB
 extension automatically maps Postgres types to reasonable chDB equivalents.
 When they don't match your use case, specify the [structure](#structure) to
-get the types you need.
+override the generated types with those you need.
 
 | Postgres    | chDB                                     | Notes                                                                  |
 | ----------- | ---------------------------------------- | ---------------------------------------------------------------------- |
@@ -333,32 +364,74 @@ get the types you need.
 | float4      | Float32                                  |                                                                        |
 | float8      | Float64                                  |                                                                        |
 | date        | Date32                                   |                                                                        |
-| time        | Time64(6)                                | Override with `String` for formats that don't support dates.           |
+| time        | Time64(6)                                | Override with `String` for formats that don't support times.           |
 | timetz      | String                                   |                                                                        |
 | timestamp   | DateTime64(6)                            | Declared with the `UTC` time zone; values cross as UTC instants.       |
 | timestamptz | DateTime64(6)                            | Declared with the `UTC` time zone; values cross as UTC instants.       |
 | numeric     | Decimal                                  |                                                                        |
 | uuid        | UUID                                     |                                                                        |
-| point       | `Point`                                  | Same two coordinates as Postgres.                                     |
-| lseg        | `LineString`                             | A line of exactly two points.                                         |
-| path        | `LineString`                             | A closed path repeats its first point.                                |
-| polygon     | `Ring`                                   | A ring closes implicitly, as a polygon does.                          |
-| box         | `Tuple(high Point, low Point)`           | The two corners, sorted as Postgres sorts.                            |
+| point       | `Point`                                  | Same two coordinates as Postgres.                                      |
+| lseg        | `LineString`                             | A line of exactly two points.                                          |
+| path        | `LineString`                             | A closed path repeats its first point.                                 |
+| polygon     | `Ring`                                   | A ring closes implicitly, as a polygon does.                           |
+| box         | `Tuple(high Point, low Point)`           | The two corners, sorted as Postgres sorts.                             |
 | circle      | `Tuple(center Point, radius Float64)`    |                                                                        |
-| line        | `Tuple(a Float64, b Float64, c Float64)` | The equation `Ax + By + C = 0`.                                       |
+| line        | `Tuple(a Float64, b Float64, c Float64)` | The equation `Ax + By + C = 0`.                                        |
 
-Array types map to `Array` of the mapped element type. ClickHouse constrains
+Array types map to `Array`s of the mapped element type. ClickHouse constrains
 nullability per column while Postgres constrains it per array, so elements are
 always `Nullable`.
 
-#### Conversion Loss
+### Limitations
 
-*   NULL array comes back as an empty array. ClickHouse has no NULL array, so
-    `COPY TO` stores `[]` for a NULL and `COPY FROM` reads `{}` back.
-*   NULL `lseg`, `path` or `polygon` comes back empty for similar reasons, as
-    they're represented as arrays in ClickHouse.
-*   Open `path` whose last point equals its first comes back closed, closed
-    being what a repeated first point means.
+Due to a few known issues and variations in the behaviors of data types
+between Postgres and chDB, the chdb extension `COPY` support has the following
+limitations:
+
+*   Cannot `COPY` relations with [row-level security] policies that apply to
+    the copying role. Postgres applies such policies by rewriting `COPY TO`
+    into a query, which the chdb extension does not support.
+*   Cannot `COPY` temporary relations, which only the session that created
+    them can read.
+*   ClickHouse has no NULL array, so `COPY TO` stores an empty array (`[]`)
+    for a `NULL`.
+*   ClickHouse represents the equivalents of `lseg`, `path`, or `polygon` as
+    arrays; thus NULL values of these types also `COPY TO` an empty array
+    (`[]`).
+*   NULL values output for a specified [structure](#structure) that doesn't
+    define the column as Nullable will be output as their default values.
+    Always explicitly define nullable columns in the [structure](#structure)
+    to avoid this conversion.
+*   An open `path` whose last point equals its first outputs as a closed path.
+*   Protobuf has no null in a repeated field, so it omits NULL values in
+    arrays.
+*   The chDB [JSON type] supports only JSON objects; override the default
+    `String` mapping for `json` and `jsonb` with `JSON` only if all values are
+    JSON object. (ClickHouse/ClickHouse#68428)
+*   The chDB [JSON type] ignores `null`s; object keys with NULL values will be
+    omitted on output. Override the default `String` mapping for `json` and
+    `jsonb` with `JSON` only if object values aren't `null` or their loss is
+    acceptable. (ClickHouse/ClickHouse#68428)
+*   The JSON, JSONCompact, and JSONColumnsWithMetadata formats always validate
+    UTF-8, so they emit bytea values with replacement characters.
+*   `COPY FROM` reads a Protobuf `Nullable` field containing an empty string
+    or zero as `NULL`. (chdb-io/chdb-core#152)
+*   `COPY TO` Parquet drops `NULL`s from a Nullable Tuple's own null map.
+    (ClickHouse/ClickHouse#112427)
+*   The Parquet, Arrow, ArrowStream, ORC, Avro, Protobuf, ProtobufList,
+    MsgPack and BSONEachRow formats have no type corresponding to Postgres
+    `time` or chDB `Time64`. Configure `time` columns as `String`s in an
+    explicit [structure](#structure) to preserve their values.
+*   Protobuf output truncates timestamp values to the second.
+*   Protobuf output does not support dates prior to 1970-01-01. Configure
+    `time` columns as `String`s in an explicit [structure](#structure) to
+    preserve their values. (ClickHouse/ClickHouse#111860)
+*   The ORC format incorrectly writes out dates after 2059-09-18 due to an
+    integer overflow. Override dates with the `String` type to avoid this
+    issue.
+*   The ORC format raises an error on `timestamp` values from 2262 and later.
+    Will be fixed when [chDB] upgrades to ClickHouse v26.7 or greater.
+    (ClickHouse/ClickHouse#109295)
 
 ## Versioning Policy
 
@@ -402,6 +475,12 @@ Copyright (c) 2026, ClickHouse
   [COPY]: https://www.postgresql.org/docs/current/sql-copy.html "Postgres Docs: COPY"
   [formats]: https://github.com/chdb-io/chdb/blob/main/refs/clickhouse-formats-settings.md#complete-format-names-table
     "chDB Docs: Complete Format Names Table"
+  [access key ID and access secret]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    "AWS Identity and Access Management: Manage access keys for IAM users"
+  [HMAC key and secret]: https://docs.cloud.google.com/storage/docs/authentication/hmackeys
+    "Google Cloud Storage: HMAC keys"
+  [access key]: https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-cli
+    "Azure: Manage storage account access keys"
   [row-level security]: https://www.postgresql.org/docs/current/ddl-rowsecurity.html
     "Postgres Docs: Row Security Policies"
   [LOAD]: https://www.postgresql.org/docs/current/sql-load.html "Postgres Docs: LOAD"

--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -480,6 +480,9 @@ static const char settings[] =
     "date_time_output_format='iso', "
     "output_format_json_quote_denormals=1, " PGCH_NATIVE_SETTINGS;
 
+#define GCS_HOST "storage.googleapis.com"
+#define AWS_HOST ".amazonaws.com"
+
 size_t
 make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** values) {
     /* Start the query. */
@@ -501,22 +504,40 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
 
     switch (ctx->extra.scheme) {
     case s3_scheme:
-    case gcs_scheme:
+    case gcs_scheme: {
         /*
          * https://clickhouse.com/docs/sql-reference/table-functions/s3#syntax
          * https://clickhouse.com/docs/sql-reference/table-functions/gcs#syntax
          */
 
         /* First parameter: the base URL. */
+        char* uri = strstr(ctx->url, "://");
+        if (!uri) {
+            /* Should not happen, validated by the hook. */
+            elog(ERROR, "chdb: malformed GCS URL %s ", ctx->url);
+        }
+        uri += strlen("://");
+        char* slash = strchr(uri, '/');
+
         if (ctx->extra.scheme == s3_scheme) {
-            PARAM("{url:String}", "url", ctx->url);
-        } else {
-            char* uri = strstr(ctx->url, "://");
-            if (!uri) {
-                /* Should not happen, validated by the hook. */
-                elog(ERROR, "chdb: malformed GCS URL %s ", ctx->url);
+            if (slash && slash - uri >= strlen(AWS_HOST) &&
+                !pg_strncasecmp(slash - strlen(AWS_HOST), AWS_HOST, strlen(AWS_HOST))) {
+                /* s3://{bucket}.{region}.amazonaws.com/{path} */
+                PARAM("{url:String}", "url", psprintf("https://%s", uri));
+            } else {
+                /* s3://{bucket}/{path} */
+                PARAM("{url:String}", "url", ctx->url);
             }
-            PARAM("{url:String}", "url", psprintf("https%s", uri));
+        } else {
+            // If it contains the host name, just emit.
+            if (slash && (slash - uri) >= strlen(GCS_HOST) &&
+                !pg_strncasecmp(uri, GCS_HOST, strlen(GCS_HOST))) {
+                /* gs://storage.googleapis.com/{bucket}/{path} */
+                PARAM("{url:String}", "url", psprintf("https://%s", uri));
+            } else {
+                /* gs://{bucket}/{path} */
+                PARAM("{url:String}", "url", psprintf("https://%s/%s", GCS_HOST, uri));
+            }
         }
 
         if (ctx->access_key[0] != '\0') {
@@ -541,6 +562,7 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
             ctx->extra.timeout
         );
         break;
+    }
     case http_scheme:
         /* https://clickhouse.com/docs/sql-reference/table-functions/url#syntax */
 

--- a/t/table-functions.pl
+++ b/t/table-functions.pl
@@ -141,22 +141,22 @@ subtest gcs => sub {
     # GCS passes url as https and ignores session_token. Otherwise the same as s3.
     check_query(
         $node, 'just FROM url',
-        qq{COPY stuff FROM 'gcs://example.org/bucket/prefix/file.csv'},
-        qr/\QHTTP response code: 404/,
+        qq{COPY stuff FROM 'gcs://bucket/prefix/file.csv'},
+        qr/\Qchdb: error fetching chDB query result/,
         qr[\QSELECT * FROM gcs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 30000],
-        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
+        qr[\Q{ url: "https://storage.googleapis.com/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'just TO url',
-        qq{COPY stuff TO 'gcs://example.org/bucket/prefix/file.csv'},
+        qq{COPY stuff TO 'gcs://storage.googleapis.com/bucket/prefix/file.csv'},
         qr/chDB Error: Code: 499/,
         qr[\QINSERT INTO FUNCTION gcs({url:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 30000],
-        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
+        qr[\Q{ url: "https://storage.googleapis.com/bucket/prefix/file.csv", format: "auto", structure: "id Nullable(Int32)" }],
     );
     check_query(
         $node, 'FROM all params',
         qq{
-            COPY stuff FROM 'gcs://example.org/bucket/prefix/file.csv' (
+            COPY stuff FROM 'gcs://bucket/prefix/file.csv' (
                 access_key 'key',
                 access_secret 'secret',
                 session_token 'big fat token',
@@ -166,9 +166,9 @@ subtest gcs => sub {
                 timeout 0
             )
         },
-        qr/\QHTTP response code: 404/,
+        qr/\Qchdb: error fetching chDB query result/,
         qr[\QSELECT * FROM gcs({url:String}, {access_key:String}, {access_secret:String}, {format:String}, {structure:String}, {compression:String}) SETTINGS allow_experimental_nullable_tuple_type=1, date_time_output_format='iso', output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, s3_truncate_on_insert = 1, s3_request_timeout_ms = 0],
-        qr[\Q{ url: "https://example.org/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", format: "parquet", structure: "id Int64", compression: "lz4" }],
+        qr[\Q{ url: "https://storage.googleapis.com/bucket/prefix/file.csv", access_key: "key", access_secret: "secret", format: "parquet", structure: "id Int64", compression: "lz4" }],
     );
 };
 

--- a/test/expected/gcs.out
+++ b/test/expected/gcs.out
@@ -5,7 +5,19 @@ CREATE TABLE gcs_times (
     months INT NOT NULL,
     days   INT NOT NULL
 );
+-- Try Public URL.
 COPY gcs_times FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+SELECT * FROM gcs_times ORDER BY id;
+ id | months | days 
+----+--------+------
+  1 |      2 |    3
+  3 |      2 |    1
+  4 |      5 |    6
+(3 rows)
+
+-- Try Cloud Storage URI.
+TRUNCATE gcs_times;
+COPY gcs_times FROM 'gcs://clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
 SELECT * FROM gcs_times ORDER BY id;
  id | months | days 
 ----+--------+------

--- a/test/expected/gcs_1.out
+++ b/test/expected/gcs_1.out
@@ -5,7 +5,19 @@ CREATE TABLE gcs_times (
     months INT NOT NULL,
     days   INT NOT NULL
 );
+-- Try Public URL.
 COPY gcs_times FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+SELECT * FROM gcs_times ORDER BY id;
+ id | months | days 
+----+--------+------
+  1 |      2 |    3
+  3 |      2 |    1
+  4 |      5 |    6
+(3 rows)
+
+-- Try Cloud Storage URI.
+TRUNCATE gcs_times;
+COPY gcs_times FROM 'gcs://clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
 SELECT * FROM gcs_times ORDER BY id;
  id | months | days 
 ----+--------+------

--- a/test/expected/s3.out
+++ b/test/expected/s3.out
@@ -5,7 +5,19 @@ CREATE TABLE s3_times (
     months INT NOT NULL,
     days   INT NOT NULL
 );
+-- Try S3 URI.
 COPY s3_times FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+SELECT * FROM s3_times ORDER BY id;
+ id | months | days 
+----+--------+------
+  1 |      2 |    3
+  3 |      2 |    1
+  4 |      5 |    6
+(3 rows)
+
+-- Try Object URL:
+TRUNCATE s3_times;
+COPY s3_times FROM 's3://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 SELECT * FROM s3_times ORDER BY id;
  id | months | days 
 ----+--------+------

--- a/test/expected/s3_1.out
+++ b/test/expected/s3_1.out
@@ -5,7 +5,19 @@ CREATE TABLE s3_times (
     months INT NOT NULL,
     days   INT NOT NULL
 );
+-- Try S3 URI.
 COPY s3_times FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+SELECT * FROM s3_times ORDER BY id;
+ id | months | days 
+----+--------+------
+  1 |      2 |    3
+  3 |      2 |    1
+  4 |      5 |    6
+(3 rows)
+
+-- Try Object URL:
+TRUNCATE s3_times;
+COPY s3_times FROM 's3://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 SELECT * FROM s3_times ORDER BY id;
  id | months | days 
 ----+--------+------

--- a/test/expected/structures.out
+++ b/test/expected/structures.out
@@ -4,8 +4,8 @@ LOAD 'chdb';
 CREATE TABLE structures (
     jp   jsonpath NOT NULL,
     xml  XML      NOT NULL,
-    j  JSON       NOT NULL,
-    jb JSONB          NULL
+    j    JSON     NOT NULL,
+    jb   JSONB        NULL
 );
 INSERT INTO structures
 VALUES ('$.x', '<html>hi</html>', '{"x": true}', '{"y": false}')
@@ -93,8 +93,8 @@ t: BSONEachRow
 CREATE TABLE structure_arrays (
     jp   jsonpath[] NOT NULL,
     xml  XML[]      NOT NULL,
-    j  JSON[]       NOT NULL,
-    jb JSONB[]      NOT NULL
+    j    JSON[]     NOT NULL,
+    jb   JSONB[]    NOT NULL
 );
 INSERT INTO structure_arrays
 VALUES ('{$.x}', '{<html>hi</html>}', '{NULL, "{\"x\": true}"}', '{"{\"y\": false}", NULL}')

--- a/test/sql/gcs.sql
+++ b/test/sql/gcs.sql
@@ -7,7 +7,13 @@ CREATE TABLE gcs_times (
     days   INT NOT NULL
 );
 
+-- Try Public URL.
 COPY gcs_times FROM 'gcs://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
+SELECT * FROM gcs_times ORDER BY id;
+
+-- Try Cloud Storage URI.
+TRUNCATE gcs_times;
+COPY gcs_times FROM 'gcs://clickhouse_public_datasets/my-test-bucket-768/data.csv.gz';
 SELECT * FROM gcs_times ORDER BY id;
 
 \set ECHO errors

--- a/test/sql/s3.sql
+++ b/test/sql/s3.sql
@@ -7,7 +7,13 @@ CREATE TABLE s3_times (
     days   INT NOT NULL
 );
 
+-- Try S3 URI.
 COPY s3_times FROM 's3://datasets-documentation/my-test-bucket-768/some_prefix/some_file_1.csv';
+SELECT * FROM s3_times ORDER BY id;
+
+-- Try Object URL:
+TRUNCATE s3_times;
+COPY s3_times FROM 's3://datasets-documentation.s3.eu-west-3.amazonaws.com/my-test-bucket-768/some_prefix/some_file_1.csv';
 SELECT * FROM s3_times ORDER BY id;
 
 \set ECHO errors

--- a/test/sql/structures.sql
+++ b/test/sql/structures.sql
@@ -5,8 +5,8 @@ LOAD 'chdb';
 CREATE TABLE structures (
     jp   jsonpath NOT NULL,
     xml  XML      NOT NULL,
-    j  JSON       NOT NULL,
-    jb JSONB          NULL
+    j    JSON     NOT NULL,
+    jb   JSONB        NULL
 );
 
 INSERT INTO structures
@@ -42,8 +42,8 @@ CREATE TABLE structures2 (LIKE structures INCLUDING ALL);
 CREATE TABLE structure_arrays (
     jp   jsonpath[] NOT NULL,
     xml  XML[]      NOT NULL,
-    j  JSON[]       NOT NULL,
-    jb JSONB[]      NOT NULL
+    j    JSON[]     NOT NULL,
+    jb   JSONB[]    NOT NULL
 );
 
 INSERT INTO structure_arrays


### PR DESCRIPTION
Expand the README with a quick synopsis to show what the extension can do and move the `Dependencies` section to the top to make super clear up-front that it needs the chdb library.

Add support for `s3://{bucket}.{region}.amazonaws.com/{path}`and `gs://{bucket}/{path}` URLs. Convert the former to `https:` so that `s3()` can use it, and the latter to `https://storage.googleapis.com/{bucket}/{path}`.

Expand the documentation:

*   Add a demo in the `Synopsis` to show early what it can do
*   Mention role permissions in the `WARNING` block
*   Mention support for `COPY TO` and `COPY FROM` in the intro to the `COPY` feature
*   Rewrap some long lines
*   Document HDFS URLs as well as the new S3 and GCP URLs
*   Link to the docs for the appropriate AWS, GCP, and Azure credentials
*   Fold file system role permission issues for `file://` URLs and conversion loss issues into a detailed "Limitations" session, which lists all known limitations and links to issues as appropriate

While at it, add some spaces for alignment of various lines of code.