### PR TITLE
Teach worker to signal unexpected exit to parent

### DIFF
--- a/src/bgw/worker.c
+++ b/src/bgw/worker.c
@@ -106,6 +106,18 @@ parse_azure_url(chdbCopyContext*, azureURLParts* parts);
 static char*
 get_local_path_from_file_url(const char* url);
 
+/* Backend-local copy of data from FixedParallelState. */
+static pid_t parent_pid;
+#if PG_VERSION_NUM >= 170000
+ProcNumber parent_proc_num = INVALID_PROC_NUMBER;
+#else
+BackendId parent_proc_num = InvalidBackendId;
+#endif
+
+/* Informs parent process that we're shutting down. */
+static void
+chdb_bgw_shutdown(int code, Datum arg);
+
 /*
  * Structure clause for the columns `attnums` names, similar to how
  * pgch_structure_from_tupdesc builds for a whole relation. A COPY column list
@@ -223,6 +235,11 @@ chdb_bgw_main(Datum main_arg) {
     /* Reconstruct the context, starting with fixed size fields in bgw_extra. */
     chdbCopyContext* ctx = palloc_object(chdbCopyContext);
     memcpy(&ctx->extra, MyBgworkerEntry->bgw_extra, sizeof(chdbCopyExtra));
+
+    /* Arrange to signal the leader if we exit. */
+    parent_pid      = ctx->extra.parent_pid;
+    parent_proc_num = ctx->extra.parent_proc_num;
+    before_shmem_exit(chdb_bgw_shutdown, PointerGetDatum(seg));
 
     /* Assemble the rest of the context from shared memory. */
     ctx->url           = shm_toc_lookup(toc, CHDB_KEY_URL, false);
@@ -767,4 +784,27 @@ get_local_path_from_file_url(const char* url) {
     }
 
     return path;
+}
+
+/*
+ * Make sure the parent tries to read from our error queue one more time.
+ * This guards against the case where we exit uncleanly without sending an
+ * ErrorResponse to the leader, for example because some code calls proc_exit
+ * directly.
+ *
+ * Also explicitly detach from dsm segment so that subsystems using
+ * on_dsm_detach() have a chance to send stats before the stats subsystem is
+ * shut down as part of a before_shmem_exit() hook.
+ *
+ * One might think this could instead be solved by carefully ordering the
+ * attaching to dsm segments, so that the pgstats segments get detached from
+ * later than the parallel query one. That turns out to not work because the
+ * stats hash might need to grow which can cause new segments to be allocated,
+ * which then will be detached from earlier.
+ */
+static void
+chdb_bgw_shutdown(int code, Datum arg) {
+    SendProcSignal(parent_pid, PROCSIG_PARALLEL_MESSAGE, parent_proc_num);
+
+    dsm_detach((dsm_segment*)DatumGetPointer(arg));
 }

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -4,6 +4,8 @@
 #if PG_VERSION_NUM >= 170000
 #include "libpq/protocol.h"
 #else
+#include "storage/backendid.h"
+typedef BackendId ProcNumber;
 #define PqMsg_Terminate 'X'
 #define PqMsg_ErrorResponse 'E'
 #define PqMsg_NoticeResponse 'N'
@@ -92,6 +94,8 @@ typedef struct chdbCopyExtra {
     scheme scheme;
     bool is_from;
     uint32_t timeout; /* request timeout in milliseconds */
+    pid_t parent_pid;
+    ProcNumber parent_proc_num;
 } chdbCopyExtra;
 
 /*

--- a/src/hook.c
+++ b/src/hook.c
@@ -273,7 +273,13 @@ chDBProcessUtilityHook(
                     .rel_id = RelationGetRelid(rel),
                     .db_id   = MyDatabaseId,
                     .role_id = GetAuthenticatedUserId(),
-                    .is_from = copy->is_from
+                    .is_from = copy->is_from,
+                    .parent_pid = MyProcPid,
+#if PG_VERSION_NUM >= 170000
+                    .parent_proc_num = MyProcNumber,
+#else
+                    .parent_proc_num = MyBackendId
+#endif
                     // .session_user_id = GetSessionUserId(),
                     // .outer_user_id = GetCurrentRoleId(),
                  },


### PR DESCRIPTION
Borrow from Postgres `parallel.c` to copy the parent PID and Proc number to the child, then have the child register callback in `before_shmem_exit()` that passes a final `PROCSIG_PARALLEL_MESSAGE` message to the parent before cldaning up the shared memory. From the Postgres `README.parallel`:

> This causes the next CHECK_FOR_INTERRUPTS() in the initiating backend
> to read and rethrow the message. For the most part, this makes error
> reporting in parallel mode "just work".

Thus the parent should now notice unexpected exits in the child and fail its command.