### PR TITLE
use pg_encoding_mbcliplen

### DIFF
--- a/src/bgw/Makefile
+++ b/src/bgw/Makefile
@@ -5,7 +5,10 @@ CH_C_DIR     = $(PGCH_DIR)/clickhouse-c
 PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
 # -isystem keeps the vendored headers' warnings out of the -Werror build.
 # PGCH_MSG_PREFIX prefixes messages pg-clickhouse-c raises like our own.
-PG_CPPFLAGS  = -isystem $(CH_C_DIR) -isystem $(PGCH_DIR) -DPGCH_MSG_PREFIX='"chdb: "'
+# clickhouse-c recopies reader errors through chc_err.msg, 256 bytes by
+# default, so match chdb_capture_error's buffer. native.c asserts the pairing.
+PG_CPPFLAGS  = -isystem $(CH_C_DIR) -isystem $(PGCH_DIR) -DPGCH_MSG_PREFIX='"chdb: "' \
+               -DCHC_ERR_MSG_LEN=4096
 PG_LDFLAGS   = -lchdb
 PG_CONFIG   ?= pg_config
 

--- a/src/bgw/native.c
+++ b/src/bgw/native.c
@@ -30,6 +30,7 @@
 #include "executor/executor.h"
 #include "executor/nodeModifyTable.h"
 #include "foreign/fdwapi.h"
+#include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "optimizer/optimizer.h"
 #include "parser/parse_relation.h"
@@ -232,6 +233,17 @@ free_native_chunks(void* arg) {
     }
 }
 
+static size_t
+clip_utf8(const char* s, size_t len, size_t limit) {
+    return len > limit ? (size_t)pg_encoding_mbcliplen(PG_UTF8, s, limit, limit) : len;
+}
+
+/* A reader error passes through chc_err.msg, which must hold all of buf. */
+StaticAssertDecl(
+    CHC_ERR_MSG_LEN >= CHDB_ERROR_QUEUE_SIZE / 4,
+    "chc_err.msg clips captured errors"
+);
+
 /*
  * Copy error minus Request ID before freeing chDB result. Result is valid
  * until next call to chdb_capture_error.
@@ -244,11 +256,11 @@ chdb_capture_error(const char* error) {
     size_t len      = 0;
 
     if (eol) {
-        len = Min((size_t)(id - error), sizeof(buf) - 1);
+        len = clip_utf8(error, (size_t)(id - error), sizeof(buf) - 1);
         memcpy(buf, error, len);
         error = eol + 1;
     }
-    size_t rest = Min(strlen(error), sizeof(buf) - 1 - len);
+    size_t rest = clip_utf8(error, strlen(error), sizeof(buf) - 1 - len);
 
     memcpy(buf + len, error, rest);
     buf[len + rest] = '\0';

--- a/test/expected/datetimes.out
+++ b/test/expected/datetimes.out
@@ -155,7 +155,7 @@ t: Parquet
 t: Arrow
 t: ArrowStream
 psql:test/utils/round-trip-formats.sql:376: ERROR:  chdb: error fetching chDB query result
-DETAIL:  Code: 321. DB::Exception: Timestamp value in column "tstz" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_D
+DETAIL:  Code: 321. DB::Exception: Timestamp value in column "tstz" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
 psql:test/utils/round-trip-formats.sql:376: STATEMENT:  COPY "datetimes2" FROM 'file:///tmp/datetimes.tmp' (format 'ORC');
 f: ORC
 t: Avro
@@ -225,7 +225,7 @@ t: Parquet
 t: Arrow
 t: ArrowStream
 psql:test/utils/round-trip-formats.sql:376: ERROR:  chdb: error fetching chDB query result
-DETAIL:  Code: 321. DB::Exception: Timestamp value in column "ts" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DAT
+DETAIL:  Code: 321. DB::Exception: Timestamp value in column "ts" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
 psql:test/utils/round-trip-formats.sql:376: STATEMENT:  COPY "datetime_arrays2" FROM 'file:///tmp/datetimes.tmp' (format 'ORC');
 f: ORC
 t: Avro

--- a/test/expected/errors.out
+++ b/test/expected/errors.out
@@ -1,0 +1,37 @@
+LOAD 'chdb';
+/****************************************************************************/
+-- Error clipping. chDB errors longer than the worker's capture buffer get
+-- clipped, and the cut has to land on a character boundary.
+CREATE TABLE clipped (id INT);
+DO $$
+DECLARE
+    path   text;
+    detail text;
+    pad    int;
+BEGIN
+    FOR pad IN 0..3 LOOP
+        -- chDB echoes the whole path, so the error outruns the buffer. Padding
+        -- walks the cut through a four byte character.
+        path := '/tmp/' || repeat('x', pad) || repeat('😃', 1100) || '.csv';
+        BEGIN
+            EXECUTE format('COPY clipped FROM %L', 'file://' || path);
+            RAISE 'chDB read a % byte path', octet_length(path);
+        EXCEPTION WHEN external_routine_exception THEN
+            GET STACKED DIAGNOSTICS detail = PG_EXCEPTION_DETAIL;
+            IF octet_length(detail) >= octet_length(path) THEN
+                RAISE 'detail not clipped: % bytes', octet_length(detail);
+            END IF;
+            -- Raises when the clip cut a character in half.
+            PERFORM length(detail::bytea, 'UTF8');
+            IF right(detail, 1) <> '😃' THEN
+                RAISE 'detail ends with %', quote_literal(right(detail, 1));
+            END IF;
+        END;
+        RAISE NOTICE 'pad % clipped on a character boundary', pad;
+    END LOOP;
+END $$;
+NOTICE:  pad 0 clipped on a character boundary
+NOTICE:  pad 1 clipped on a character boundary
+NOTICE:  pad 2 clipped on a character boundary
+NOTICE:  pad 3 clipped on a character boundary
+DROP TABLE clipped;

--- a/test/sql/errors.sql
+++ b/test/sql/errors.sql
@@ -1,0 +1,36 @@
+LOAD 'chdb';
+
+/****************************************************************************/
+-- Error clipping. chDB errors longer than the worker's capture buffer get
+-- clipped, and the cut has to land on a character boundary.
+CREATE TABLE clipped (id INT);
+
+DO $$
+DECLARE
+    path   text;
+    detail text;
+    pad    int;
+BEGIN
+    FOR pad IN 0..3 LOOP
+        -- chDB echoes the whole path, so the error outruns the buffer. Padding
+        -- walks the cut through a four byte character.
+        path := '/tmp/' || repeat('x', pad) || repeat('😃', 1100) || '.csv';
+        BEGIN
+            EXECUTE format('COPY clipped FROM %L', 'file://' || path);
+            RAISE 'chDB read a % byte path', octet_length(path);
+        EXCEPTION WHEN external_routine_exception THEN
+            GET STACKED DIAGNOSTICS detail = PG_EXCEPTION_DETAIL;
+            IF octet_length(detail) >= octet_length(path) THEN
+                RAISE 'detail not clipped: % bytes', octet_length(detail);
+            END IF;
+            -- Raises when the clip cut a character in half.
+            PERFORM length(detail::bytea, 'UTF8');
+            IF right(detail, 1) <> '😃' THEN
+                RAISE 'detail ends with %', quote_literal(right(detail, 1));
+            END IF;
+        END;
+        RAISE NOTICE 'pad % clipped on a character boundary', pad;
+    END LOOP;
+END $$;
+
+DROP TABLE clipped;


### PR DESCRIPTION
avoids truncating inside multibyte character