### PR TITLE
Replace copy_from bool with `chdbCmdType` type

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -262,7 +262,7 @@ place_fd(int fd, int target) {
  * the backend's Postgres state, so it may only _exit.
  */
 static void
-exec_helper(chdbHelper* h, const char* program, bool is_from) {
+exec_helper(chdbHelper* h, const char* program, chdbCmdType cmd_type) {
     char* const argv[] = { (char*)program, NULL };
     int null           = open("/dev/null", O_RDWR);
 
@@ -271,9 +271,9 @@ exec_helper(chdbHelper* h, const char* program, bool is_from) {
     h->setup_peer = reserve_fd(h->setup_peer);
     null          = reserve_fd(null);
 
-    /* The channel the copy does not use must not reach the backend's own. */
-    if (!place_fd(is_from ? null : h->data_peer, STDIN_FILENO) ||
-        !place_fd(is_from ? h->data_peer : null, STDOUT_FILENO) ||
+    /* The channel the query does not use must not reach the backend's own. */
+    if (!place_fd(cmd_type == CHDB_CMD_INSERT ? h->data_peer : null, STDIN_FILENO) ||
+        !place_fd(cmd_type == CHDB_CMD_INSERT ? null : h->data_peer, STDOUT_FILENO) ||
         !place_fd(h->err_peer, STDERR_FILENO) ||
         !place_fd(h->setup_peer, CHDB_SETUP_FD)) {
         _exit(126);
@@ -348,16 +348,15 @@ append_string(StringInfo buf, const char* str) {
 static void
 build_setup(
     StringInfo buf,
-    bool is_from,
+    chdbCmdType cmd_type,
     const char* query,
     char* const* names,
     char* const* values,
     size_t nparams
 ) {
-    uint8_t flag   = is_from ? 1 : 0;
     uint16_t count = (uint16_t)nparams;
 
-    appendBinaryStringInfo(buf, (char*)&flag, sizeof(flag));
+    appendBinaryStringInfo(buf, (char*)&cmd_type, sizeof(cmd_type));
     append_string(buf, query);
     appendBinaryStringInfo(buf, (char*)&count, sizeof(count));
     for (size_t i = 0; i < nparams; i++) {
@@ -392,7 +391,7 @@ open_channel(int* first, int* second, bool duplex) {
 
 chdbHelper*
 chdb_helper_start(
-    bool is_from,
+    chdbCmdType cmd_type,
     const char* query,
     char* const* names,
     char* const* values,
@@ -429,7 +428,7 @@ chdb_helper_start(
 
     StringInfoData setup;
     initStringInfo(&setup);
-    build_setup(&setup, is_from, query, names, values, nparams);
+    build_setup(&setup, cmd_type, query, names, values, nparams);
 
     open_channel(&h->data, &h->data_peer, true);
     open_channel(&h->err, &h->err_peer, false);
@@ -450,7 +449,7 @@ chdb_helper_start(
         ereport(ERROR, errcode_for_file_access(), errmsg("chdb: could not fork: %m"));
     }
     if (h->pid == 0) {
-        exec_helper(h, program, is_from);
+        exec_helper(h, program, cmd_type);
     }
     elog(DEBUG1, "chdb: chdb_helper pid %d", (int)h->pid);
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -2,13 +2,14 @@
 #define CHDB_HELPER_H
 
 #include "postgres.h"
+#include "setup.h"
 
 /*
  * The chdb_helper process answering one COPY. The two sides meet on fixed
  * descriptors:
  *
- *   fd 0   Native blocks in, COPY TO
- *   fd 1   Native blocks out, COPY FROM
+ *   fd 0   Native blocks in, INSERT, COPY TO
+ *   fd 1   Native blocks out, SELECT, COPY FROM
  *   fd 2   error text
  *   fd 3   setup payload, closed once written
  *   exit   0 on success, CHDB_HELPER_LOST_BACKEND when the channel broke and
@@ -24,7 +25,7 @@ typedef struct chdbHelper chdbHelper;
  */
 extern chdbHelper*
 chdb_helper_start(
-    bool is_from,
+    chdbCmdType cmd_type,
     const char* query,
     char* const* names,
     char* const* values,

--- a/src/helper/chdb_helper.c
+++ b/src/helper/chdb_helper.c
@@ -270,11 +270,11 @@ run_insert(chdb_connection conn, str query, const params* par) {
 int
 main(void) {
     size_t len;
-    char* setup   = read_setup(&len);
-    cursor cur    = { setup, setup + len };
-    bool is_from  = take1(&cur) != 0;
-    str query     = take_str(&cur);
-    uint16_t npar = take2(&cur);
+    char* setup          = read_setup(&len);
+    cursor cur           = { setup, setup + len };
+    chdbCmdType cmd_type = take1(&cur);
+    str query            = take_str(&cur);
+    uint16_t npar        = take2(&cur);
 
     size_t nalloc       = npar ? npar : 1;
     const char** names  = not_null(calloc(nalloc, sizeof(*names)));
@@ -303,8 +303,8 @@ main(void) {
         fail("chdb: unable to connect to chDB");
     }
 
-    int status =
-        is_from ? run_select(*conn, query, &par) : run_insert(*conn, query, &par);
+    int status = cmd_type == CHDB_CMD_SELECT ? run_select(*conn, query, &par)
+                                             : run_insert(*conn, query, &par);
 
     fflush(stderr);
     chdb_close_conn(conn);

--- a/src/hook/copy.c
+++ b/src/hook/copy.c
@@ -174,9 +174,9 @@ chdb_copy(chdbCopyContext* ctx) {
 
     /* Hand off to the helper. */
     chdbHelper* helper =
-        chdb_helper_start(ctx->is_from, ch_query.data, names, values, param_count);
+        chdb_helper_start(ctx->cmd_type, ch_query.data, names, values, param_count);
     uint64_t num_rows =
-        ctx->is_from
+        ctx->cmd_type == CHDB_CMD_SELECT
             ? chdb_native_receive(
                   ctx->rel, ctx->attnums, ctx->rtable, ctx->rteperminfos, helper
               )
@@ -209,7 +209,7 @@ make_ch_query(chdbCopyContext* ctx, StringInfo query, char** names, char** value
     appendStringInfo(
         query,
         "%s %s(",
-        ctx->is_from ? "SELECT * FROM" : "INSERT INTO FUNCTION",
+        ctx->cmd_type == CHDB_CMD_SELECT ? "SELECT * FROM" : "INSERT INTO FUNCTION",
         table_function[ctx->scheme]
     );
 

--- a/src/hook/copy.h
+++ b/src/hook/copy.h
@@ -6,6 +6,8 @@
 #include "nodes/pg_list.h"
 #include "utils/relcache.h"
 
+#include "../setup.h"
+
 /* URL schemes that the COPY hook understands. */
 typedef enum scheme {
     http_scheme,
@@ -28,7 +30,7 @@ typedef struct chdbCopyContext {
     List* rtable;
     List* rteperminfos;
     scheme scheme;
-    bool is_from;
+    chdbCmdType cmd_type;
     uint32_t timeout;   /* request timeout in milliseconds */
     int64_t max_memory; /* max_memory_usage setting, 0 for none */
     /* Table function options; keep in sync with CHDB_MAX_TABLEFUNC_ARGS. */

--- a/src/hook/hook.c
+++ b/src/hook/hook.c
@@ -318,9 +318,9 @@ chDBProcessUtilityHook(
                 check_server_file_privileges(copy->is_from);
             }
             chdbCopyContext ctx = {
-                .scheme  = scheme,
-                .is_from = copy->is_from,
-                .url     = copy->filename,
+                .scheme   = scheme,
+                .cmd_type = copy->is_from ? CHDB_CMD_SELECT : CHDB_CMD_INSERT,
+                .url      = copy->filename,
             };
 
             open_copy_relation(copy, &ctx);

--- a/src/setup.h
+++ b/src/setup.h
@@ -4,15 +4,20 @@
 /* Where the backend hands the helper its setup payload. */
 #define CHDB_SETUP_FD 3
 
+/* Type of query we ask the helper to execute. */
+typedef uint8_t chdbCmdType;
+#define CHDB_CMD_SELECT 'S' /* SELECT, COPY FROM */
+#define CHDB_CMD_INSERT 'I' /* COPY TO */
+
 /*
  * The payload the backend writes to CHDB_SETUP_FD and then closes. The helper
  * reads it whole before touching either data channel.
  * Fields are native endian.
  *
- *   uint8    1 for COPY FROM, 0 for COPY TO
- *   string   query
- *   uint16   parameter count
- *   string   parameter name and value, repeated
+ *   chdbCmdType command type
+ *   string      query
+ *   uint16      parameter count
+ *   string      parameter name and value, repeated
  *
  * A string is a uint32 byte count followed by that many bytes, unterminated.
  */
@@ -20,7 +25,7 @@
 /* Refuse a payload larger than this rather than sizing a buffer from it. */
 #define CHDB_SETUP_MAX (16 * 1024 * 1024)
 
-/* Exit status telling the backend the copy broke rather than the query. */
+/* Exit status telling the backend execution broke rather than the query. */
 #define CHDB_HELPER_LOST_BACKEND 2
 
 #endif /* CHDB_SETUP_H */


### PR DESCRIPTION
In preparation for supporting queries other than `COPY`, add the `chdbCmdType` typedef, a single byte defining the type of query to be run. Define constants for selecting data (`SELECT` and `COPY FROM`), inserting data (`INSERT` and `COPY TO`). Should we add support for queries that returns no results (DDL), the SELECT mode will work equally well. For now, just evaluate the select and insert variants to support the current `COPY` feature.