### PR TITLE
Upgrade chdb to v26.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         arch: [amd64, arm64]
     name: 🐘 PostgreSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }}
     runs-on: ubuntu-${{ matrix.arch == 'amd64' && 'latest' || '24.04-arm' }}
-    env: { chdb_version: v26.5.1-rc.3 }
+    env: { chdb_version: v26.7.0 }
     services:
       kv-rest:
         image: ghcr.io/theory/kv-rest
@@ -44,6 +44,7 @@ jobs:
       - name: Install chDB
         run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
+      - run: sudo chmod +r /usr/local/include/chdb.*
       - name: Build
         run: make -j $(nproc)
       - name: Install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     name: 🔎 Lint Code
     runs-on: ubuntu-latest
-    env: { pg: 19, chdb_version: v26.5.1-rc.3 }
+    env: { pg: 19, chdb_version: 26.7.0 }
     steps:
       - name: Checkout the Repository
         uses: actions/checkout@v7
@@ -35,6 +35,7 @@ jobs:
       - name: Install chDB
         run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
+      - run: sudo chmod +r /usr/local/include/chdb.*
       - name: Add Postgres to Path
         run: echo /usr/lib/postgresql/${{ env.pg }}/bin >> "$GITHUB_PATH"
       - name: Generate compile_commands.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Release on GitHub and PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
-    env: { pg: 19, chdb_version: v26.5.1-rc.3 }
+    env: { pg: 19, chdb_version: 26.7.0 }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -29,6 +29,7 @@ jobs:
       - name: Install chDB
         run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
         env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
+      - run: sudo chmod +r /usr/local/include/chdb.*
       - name: Bundle the Release
         id: bundle
         run: pgxn-bundle

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Dependencies
 ------------
 
 The `chdb` extension requires PostgreSQL 16 or higher and the [chDB] library
-v26.5.1 or greater. The simplest way to install it is via the [lib.chdb.io]
+v26.7.0 or greater. The simplest way to install it is via the [lib.chdb.io]
 shell script:
 
 ```sh

--- a/doc/chdb.md
+++ b/doc/chdb.md
@@ -10,7 +10,7 @@ CREATE EXTENSION
 # SELECT * FROM chdb_query('version()') AS (version text);
  version
 ----------
- 26.5.1.1
+ 26.7.2.1
 (1 row)
 ```
 

--- a/doc/chdb_hook.md
+++ b/doc/chdb_hook.md
@@ -456,12 +456,8 @@ limitations:
 *   Protobuf output does not support dates prior to 1970-01-01. Configure
     `time` columns as `String`s in an explicit [structure](#structure) to
     preserve their values. (ClickHouse/ClickHouse#111860)
-*   The ORC format incorrectly writes out dates after 2059-09-18 due to an
-    integer overflow. Override dates with the `String` type to avoid this
-    issue.
-*   The ORC format raises an error on `timestamp` values from 2262 and later.
-    Will be fixed when [chDB] upgrades to ClickHouse v26.7 or greater.
-    (ClickHouse/ClickHouse#109295)
+*   The CSVWithNames and CSVWithNamesAndTypes formats cannot currently import
+    `NULL` box or circle values. (ClickHouse/ClickHouse#115523)
 
 ## Versioning Policy
 

--- a/src/helper.c
+++ b/src/helper.c
@@ -150,7 +150,8 @@ stop_helper(void* arg) {
 
 /*
  * The helper's error text, minus a Request ID line that would differ between
- * runs and swamp the message. NULL when the helper said nothing.
+ * runs and swamp the message and minus a chDB version. NULL when the helper
+ * said nothing.
  *
  * The capture stops at whatever byte filled the buffer, so pull the cut back
  * to a character boundary: half a character reaches the client as text and
@@ -174,6 +175,13 @@ helper_error(chdbHelper* h) {
     const char* eol = id ? strchr(id, '\n') : NULL;
     if (eol) {
         memmove((char*)id, eol + 1, strlen(eol + 1) + 1);
+        h->err_len = strlen(h->err_buf);
+    }
+
+    const char* version = strstr(h->err_buf, " (version ");
+    const char* close   = version ? strchr(version, ')') : NULL;
+    if (close) {
+        memmove((char*)version, close + 1, strlen(close + 1) + 1);
         h->err_len = strlen(h->err_buf);
     }
 

--- a/test/expected/datetimes.out
+++ b/test/expected/datetimes.out
@@ -113,7 +113,6 @@ f: Protobuf
 f: ProtobufList
 t: MsgPack
 t: BSONEachRow
--- Try again with greater time spans, which ORC and Protobuf dislike.
 -- Protobuf chokes on dates prior to 1970-01-01, so avoid them. https://github.com/ClickHouse/ClickHouse/issues/111860
 INSERT INTO datetimes
 VALUES (NULL, NULL, '2299-12-31 23:59:59.999999Z', '1970-01-01 00:00:00Z', '1900-01-01', '00:00:00', '24:00:00', '00:00:00+1559', '24:00:00-1559', '-178000000 years');
@@ -154,11 +153,7 @@ t: RowBinaryWithNamesAndTypes
 t: Parquet
 t: Arrow
 t: ArrowStream
-psql:test/utils/round-trip-formats.sql:376: ERROR:  chdb: error executing chDB query
-DETAIL:  Code: 321. DB::Exception: Timestamp value in column "tstz" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
-CONTEXT:  query: SELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
-psql:test/utils/round-trip-formats.sql:376: STATEMENT:  COPY "datetimes2" FROM 'file:///tmp/datetimes.tmp' (format 'ORC');
-f: ORC
+t: ORC
 t: Avro
 f: Protobuf
 f: ProtobufList
@@ -225,19 +220,15 @@ t: RowBinaryWithNamesAndTypes
 t: Parquet
 t: Arrow
 t: ArrowStream
-psql:test/utils/round-trip-formats.sql:376: ERROR:  chdb: error executing chDB query
-DETAIL:  Code: 321. DB::Exception: Timestamp value in column "ts" is out of range for DateTime64: seconds=10413791999, nanoseconds=999999000: (in file/uri /tmp/datetimes.tmp): While executing ORCBlockInputFormat: While executing File. (VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE)
-CONTEXT:  query: SELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
-psql:test/utils/round-trip-formats.sql:376: STATEMENT:  COPY "datetime_arrays2" FROM 'file:///tmp/datetimes.tmp' (format 'ORC');
-f: ORC
+t: ORC
 t: Avro
 psql:test/utils/round-trip-formats.sql:402: ERROR:  chdb: error finishing chDB query
-DETAIL:  Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW) (version 26.5.1.1)
+DETAIL:  Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW)
 CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
 psql:test/utils/round-trip-formats.sql:402: STATEMENT:  COPY "datetime_arrays" TO 'file:///tmp/datetimes.tmp' (format 'Protobuf');
 f: Protobuf
 psql:test/utils/round-trip-formats.sql:421: ERROR:  chdb: error finishing chDB query
-DETAIL:  Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW) (version 26.5.1.1)
+DETAIL:  Code: 407. DB::Exception: Convert overflow. (DECIMAL_OVERFLOW)
 CONTEXT:  query: INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
 psql:test/utils/round-trip-formats.sql:421: STATEMENT:  COPY "datetime_arrays" TO 'file:///tmp/datetimes.tmp' (format 'ProtobufList');
 f: ProtobufList

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -40,18 +40,18 @@ SELECT * FROM chdb_query('SELECT 1 WHERE 0') AS (x int, y text);
 
 -- Should fail with column type mismatch.
 SELECT * FROM chdb_query('SELECT version()') AS (version int);
-ERROR:  invalid input syntax for type integer: "26.5.1.1"
+ERROR:  invalid input syntax for type integer: "26.7.2.1"
 -- Working examples.
 SELECT * FROM chdb_query('SELECT version()') AS (version text);
  version  
 ----------
- 26.5.1.1
+ 26.7.2.1
 (1 row)
 
 SELECT * FROM chdb_query('SELECT 42, version()') AS (id int, version text);
  id | version  
 ----+----------
- 42 | 26.5.1.1
+ 42 | 26.7.2.1
 (1 row)
 
 SELECT * FROM chdb_query(

--- a/test/expected/geos.out
+++ b/test/expected/geos.out
@@ -30,8 +30,8 @@ t: TabSeparatedWithNamesAndTypes
 t: TabSeparatedRawWithNames
 t: TabSeparatedRawWithNamesAndTypes
 t: CSV
-t: CSVWithNames
-t: CSVWithNamesAndTypes
+f: CSVWithNames
+f: CSVWithNamesAndTypes
 t: CustomSeparated
 t: CustomSeparatedWithNames
 t: CustomSeparatedWithNamesAndTypes
@@ -80,9 +80,7 @@ INSERT INTO geo_nulls
 VALUES ('0,0', '(1,1),(2,2)', '((11,11),(12,12))', '((11,11),(13,13))', '((11,12),(13,13),(14,14))', '((11,12),(13,13),(14,14))', '1,1,1')
      , (NULL, NULL, NULL, NULL, NULL, NULL, NULL)
 ;
--- Execute round-trip to all supported formats. Parquet drops a Nullable
--- Tuple's own null map, so a NULL point cannot be read back:
--- https://github.com/ClickHouse/ClickHouse/issues/112427
+-- Execute round-trip to all supported formats.
 -- Protobuf reads a Nullable field holding its default back as NULL, so the
 -- point at the origin does not survive:
 -- https://github.com/chdb-io/chdb-core/issues/152
@@ -99,8 +97,76 @@ t: TabSeparatedWithNamesAndTypes
 t: TabSeparatedRawWithNames
 t: TabSeparatedRawWithNamesAndTypes
 t: CSV
-t: CSVWithNames
-t: CSVWithNamesAndTypes
+psql:test/utils/round-trip-formats.sql:82: ERROR:  chdb: error executing chDB query
+DETAIL:  Code: 27. DB::Exception: Cannot parse input: expected ',' before: '\n': (at row 2)
+: 
+Row 1:
+Column 0,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "0"
+Column 1,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "0"
+Column 2,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+Column 3,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "-1"
+Column 4,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "0"
+Column 5,   name: lseg, type: LineString,                                       parsed text: "<DOUBLE QUOTE>[(11,11),(12,12)]<DOUBLE QUOTE>"
+Column 6,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "13"
+Column 7,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "13"
+Column 8,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "11"
+Column 9,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "11"
+Column 10,  name: path, type: LineString,                                       parsed text: "<DOUBLE QUOTE>[(11,12),(13,13),(14,14),(11,12)]<DOUBLE QUOTE>"
+Column 11,  name: poly, type: Ring,                                             parsed text: "<DOUBLE QUOTE>[(11,12),(13,13),(14,14)]<DOUBLE QUOTE>"
+Column 12,  name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+Column 13,  name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+Column 14,  name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+
+Row 2:
+Column 0,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+Column 1,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+Column 2,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<DOUBLE QUOTE>[]<DOUBLE QUOTE>"
+Column 3,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+Column 4,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<DOUBLE QUOTE>[]<DOUBLE QUOTE>"
+Column 5,   name: lseg, type: LineString,                                       parsed text: "<DOUBLE QUOTE>[]<DOUBLE QUOTE>"
+Column 6,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+ERROR: Line feed found where delimiter (,) is expected. It's like your file has less columns than expected.
+And if your file has the right number of columns, maybe it has unescaped quotes in values.
+
+: (in file/uri /tmp/geos.tmp): While executing ParallelParsingBlockInputFormat: While executing File. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)
+CONTEXT:  query: SELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
+psql:test/utils/round-trip-formats.sql:82: STATEMENT:  COPY "geo_nulls2" FROM 'file:///tmp/geos.tmp' (format 'CSVWithNames');
+f: CSVWithNames
+psql:test/utils/round-trip-formats.sql:90: ERROR:  chdb: error executing chDB query
+DETAIL:  Code: 27. DB::Exception: Cannot parse input: expected ',' before: '\n': (at row 2)
+: 
+Row 1:
+Column 0,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "0"
+Column 1,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "0"
+Column 2,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+Column 3,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "-1"
+Column 4,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "0"
+Column 5,   name: lseg, type: LineString,                                       parsed text: "<DOUBLE QUOTE>[(11,11),(12,12)]<DOUBLE QUOTE>"
+Column 6,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "13"
+Column 7,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "13"
+Column 8,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "11"
+Column 9,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "11"
+Column 10,  name: path, type: LineString,                                       parsed text: "<DOUBLE QUOTE>[(11,12),(13,13),(14,14),(11,12)]<DOUBLE QUOTE>"
+Column 11,  name: poly, type: Ring,                                             parsed text: "<DOUBLE QUOTE>[(11,12),(13,13),(14,14)]<DOUBLE QUOTE>"
+Column 12,  name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+Column 13,  name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+Column 14,  name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "1"
+
+Row 2:
+Column 0,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+Column 1,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+Column 2,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<DOUBLE QUOTE>[]<DOUBLE QUOTE>"
+Column 3,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+Column 4,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<DOUBLE QUOTE>[]<DOUBLE QUOTE>"
+Column 5,   name: lseg, type: LineString,                                       parsed text: "<DOUBLE QUOTE>[]<DOUBLE QUOTE>"
+Column 6,   name: <SKIPPED COLUMN>, type: Nothing,                                          parsed text: "<BACKSLASH>N"
+ERROR: Line feed found where delimiter (,) is expected. It's like your file has less columns than expected.
+And if your file has the right number of columns, maybe it has unescaped quotes in values.
+
+: (in file/uri /tmp/geos.tmp): While executing ParallelParsingBlockInputFormat: While executing File. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)
+CONTEXT:  query: SELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
+psql:test/utils/round-trip-formats.sql:90: STATEMENT:  COPY "geo_nulls2" FROM 'file:///tmp/geos.tmp' (format 'CSVWithNamesAndTypes');
+f: CSVWithNamesAndTypes
 t: CustomSeparated
 t: CustomSeparatedWithNames
 t: CustomSeparatedWithNamesAndTypes
@@ -124,11 +190,7 @@ t: Native
 t: RowBinary
 t: RowBinaryWithNames
 t: RowBinaryWithNamesAndTypes
-psql:test/utils/round-trip-formats.sql:352: ERROR:  chdb: error executing chDB query
-DETAIL:  Code: 53. DB::Exception: Requested type of column p doesn't match parquet schema: parquet type is Tuple, requested type is Nullable(Point): (in file/uri /tmp/geos.tmp): While executing ParquetV3BlockInputFormat: While executing File. (TYPE_MISMATCH)
-CONTEXT:  query: SELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
-psql:test/utils/round-trip-formats.sql:352: STATEMENT:  COPY "geo_nulls2" FROM 'file:///tmp/geos.tmp' (format 'Parquet');
-f: Parquet
+t: Parquet
 t: Arrow
 t: ArrowStream
 t: ORC
@@ -194,11 +256,7 @@ t: Native
 t: RowBinary
 t: RowBinaryWithNames
 t: RowBinaryWithNamesAndTypes
-psql:test/utils/round-trip-formats.sql:352: ERROR:  chdb: error executing chDB query
-DETAIL:  Code: 53. DB::Exception: Requested type of column p doesn't match parquet schema: parquet type is Tuple, requested type is Nullable(Point): (in file/uri /tmp/geos.tmp): While executing ParquetV3BlockInputFormat: While executing File. (TYPE_MISMATCH)
-CONTEXT:  query: SELECT * FROM file({path:String}, {format:String}, {structure:String}) SETTINGS allow_experimental_nullable_tuple_type=1, output_format_json_quote_denormals=1, output_format_native_encode_types_in_binary_format=0,output_format_native_write_json_as_string=1, engine_file_truncate_on_insert=1
-psql:test/utils/round-trip-formats.sql:352: STATEMENT:  COPY "geo_arrays2" FROM 'file:///tmp/geos.tmp' (format 'Parquet');
-f: Parquet
+t: Parquet
 t: Arrow
 t: ArrowStream
 t: ORC

--- a/test/sql/datetimes.sql
+++ b/test/sql/datetimes.sql
@@ -34,7 +34,6 @@ INSERT INTO datetimes
 VALUES ('2026-07-23 20:43:10.836612', '2026-07-23 20:43:27.363', '2026-07-23 20:43:50.944042+00', '2026-07-23 13:44:46.8445-07', '2026-07-23', '13:45:15.416013', '13:45:24.282', '13:45:35.306886-07', '13:45:49.17-07', '1 day');
 \i test/utils/round-trip-formats.sql
 
--- Try again with greater time spans, which ORC and Protobuf dislike.
 -- Protobuf chokes on dates prior to 1970-01-01, so avoid them. https://github.com/ClickHouse/ClickHouse/issues/111860
 INSERT INTO datetimes
 VALUES (NULL, NULL, '2299-12-31 23:59:59.999999Z', '1970-01-01 00:00:00Z', '1900-01-01', '00:00:00', '24:00:00', '00:00:00+1559', '24:00:00-1559', '-178000000 years');

--- a/test/sql/geos.sql
+++ b/test/sql/geos.sql
@@ -44,9 +44,7 @@ VALUES ('0,0', '(1,1),(2,2)', '((11,11),(12,12))', '((11,11),(13,13))', '((11,12
      , (NULL, NULL, NULL, NULL, NULL, NULL, NULL)
 ;
 
--- Execute round-trip to all supported formats. Parquet drops a Nullable
--- Tuple's own null map, so a NULL point cannot be read back:
--- https://github.com/ClickHouse/ClickHouse/issues/112427
+-- Execute round-trip to all supported formats.
 -- Protobuf reads a Nullable field holding its default back as NULL, so the
 -- point at the origin does not survive:
 -- https://github.com/chdb-io/chdb-core/issues/152


### PR DESCRIPTION
No more pre-releases! This update fixes ORC DateTime and Parquet geometric issues, but now `CSVWithNames` and `CSVWithNamesAndTypes` fail on `NULL` box and circle values with rather verbose error output. Reported the issue in ClickHouse/ClickHouse#115523 and including the errors in the expected error output for now.

Add a `chmod +r /usr/local/include/chdb.*` step to the workflows, as this release installs the header file with permissions only for the installing user, which prevents the CI user from compiling it. Hopefully can be removed in a future release.

Also strip out `(version xxx)` from error messages, which previously appeared in the DateTime overflow errors.