### PR TITLE
ci: configure AWS credentials right before the step that needs them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
         with:
           version: ${{ matrix.pg }}
           packages: libkrb5-dev libipc-run-perl
-      - name: Configure AWS credentials # for s3.sql round-trip test
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.aws_role_to_assume }}
-          role-session-name: ${{ github.run_id }}
-          aws-region: us-east-2
       - name: Tweak Permissions # for cache restore
         run: sudo chmod a+rwx /usr/local/lib /usr/local/include
       - name: Cache chDB
@@ -54,6 +48,12 @@ jobs:
         run: make -j $(nproc)
       - name: Install
         run: sudo make install
+      - name: Configure AWS credentials # for s3.sql round-trip test
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.aws_role_to_assume }}
+          role-session-name: ${{ github.run_id }}
+          aws-region: us-east-2
       - name: Test
         run: make installcheck
         # https://console.cloud.google.com/storage/settings;tab=interoperability?project=ch-pg-test


### PR DESCRIPTION
## Summary
- The `Configure AWS credentials` step ran early in the job, before the `Install chDB` step that pipes `curl -sL https://lib.chdb.io | sudo -E bash`. Because `-E` forwards the environment into the root shell, live OIDC-derived AWS credentials were readable by that unrelated third-party install script (and by the `Build`/`Install` steps) for the whole window in between.
- Moves the credential step to immediately precede the `Test` step (the only one that actually needs the credentials, for the `s3.sql` round-trip test), shrinking the exposure window to just the step that uses them.
