### PR TITLE
Run all tests concurrently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ EXTVERSION   = $(shell grep -m 1 'default_version' chdb.control | \
 DISTVERSION  = $(shell grep -m 1 '^[[:space:]]\{2\}"version":' META.json | \
                sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",\{0,1\}/\1/')
 
-MAX_CONCURRENT_TESTS ?= 6
-
 # Header-only dependencies, vendored as submodules. clickhouse-c comes from
 # pg-clickhouse-c's own pin, its signatures naming clickhouse-c types, so a
 # second checkout on the include path would silently win.
@@ -16,7 +14,7 @@ DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EX
 DOCS         = $(wildcard doc/*.md)
 TESTS        ?= $(wildcard test/sql/*.sql)
 REGRESS      = --schedule test/schedule
-REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION) --max-concurrent-tests $(MAX_CONCURRENT_TESTS)
+REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 MODULE_big   = $(EXTENSION)
 PG_CONFIG   ?= pg_config
 TAP_TESTS   ?= 1
@@ -97,7 +95,7 @@ uninstall: uninstall-helper
 
 .PHONY: test/schedule # Depends on $(TESTS), so always rebuild.
 test/schedule:
-	@perl -E 'say "test: ", join " ", splice @ARGV, 0, $(MAX_CONCURRENT_TESTS) while @ARGV' $(patsubst test/sql/%.sql,%,$(TESTS)) > $@
+	@echo "test: $(patsubst test/sql/%.sql,%,$(TESTS))" > $@
 
 installcheck: test/schedule
 

--- a/src/chdb.c
+++ b/src/chdb.c
@@ -25,8 +25,6 @@ PG_MODULE_MAGIC_EXT(.name = "chdb", .version = PGCHCB_VERSION);
 PG_MODULE_MAGIC;
 #endif
 
-PG_FUNCTION_INFO_V1(chdb_query);
-
 /*
  * Function returns the full chdb extension library version.
  */
@@ -71,6 +69,7 @@ _PG_init(void) {
  * mapping chDB values to the Postgres types named in the caller's column
  * definition list.
  */
+PG_FUNCTION_INFO_V1(chdb_query);
 Datum
 chdb_query(PG_FUNCTION_ARGS) {
     char* sql             = text_to_cstring(PG_GETARG_TEXT_P(0));


### PR DESCRIPTION
Since switching from a background worker to a helper app, we are no longer limited by `max_worker_processes`. So run all of the tests in parallel instead of breaking them up into groups of six. This lets the tests complete more quickly.