### PR TITLE
Add libchdb bundling support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         arch: [amd64, arm64]
     name: 🐘 PostgreSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }}
     runs-on: ubuntu-${{ matrix.arch == 'amd64' && 'latest' || '24.04-arm' }}
-    env: { chdb_version: v26.7.0 }
+    env: { BUNDLE_LIBCHDB: 1 }
     services:
       kv-rest:
         image: ghcr.io/theory/kv-rest
@@ -31,24 +31,22 @@ jobs:
         with:
           version: ${{ matrix.pg }}
           packages: libkrb5-dev libipc-run-perl
-      - name: Tweak Permissions # for cache restore
-        run: sudo chmod a+rwx /usr/local/lib /usr/local/include
+      # make BUNDLE_LIBCHDB=1 installs libchdb if missing.
+      - name: Get chDB Version
+        id: chdb
+        run: make libchdb-variables >> $GITHUB_OUTPUT
       - name: Cache chDB
         id: cache-chdb
         uses: actions/cache@v6
         with:
-          key: chdb-${{ env.chdb_version }}-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ steps.chdb.outputs.directory }}
           path: |
-            /usr/local/lib/libchdb.so
-            /usr/local/include/chdb.*
-      - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
-        env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
-      - run: sudo chmod +r /usr/local/include/chdb.*
+            ${{ steps.chdb.outputs.directory }}/lib/libchdb.*
+            ${{ steps.chdb.outputs.directory }}/include/chdb.h
       - name: Build
         run: make -j $(nproc)
       - name: Install
-        run: sudo make install
+        run: sudo --preserve-env=BUNDLE_LIBCHDB make install
       - name: Configure AWS credentials # for s3.sql round-trip test
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     name: 🔎 Lint Code
     runs-on: ubuntu-latest
-    env: { pg: 19, chdb_version: 26.7.0 }
+    env: { pg: 19, BUNDLE_LIBCHDB: 1 }
     steps:
       - name: Checkout the Repository
         uses: actions/checkout@v7
@@ -22,22 +22,18 @@ jobs:
           packages: libkrb5-dev clang-tidy bear
       - name: Install pre-commit
         run: make debian-install-lint
-      - name: Tweak Permissions # for cache restore
-        run: sudo chmod a+rwx /usr/local/lib /usr/local/include
+      # make BUNDLE_LIBCHDB=1 installs libchdb if missing.
+      - name: Get chDB Version
+        id: chdb
+        run: make libchdb-variables >> $GITHUB_OUTPUT
       - name: Cache chDB
         id: cache-chdb
         uses: actions/cache@v6
         with:
-          key: chdb-${{ env.chdb_version }}-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ steps.chdb.outputs.directory }}
           path: |
-            /usr/local/lib/libchdb.so
-            /usr/local/include/chdb.*
-      - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
-        env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
-      - run: sudo chmod +r /usr/local/include/chdb.*
-      - name: Add Postgres to Path
-        run: echo /usr/lib/postgresql/${{ env.pg }}/bin >> "$GITHUB_PATH"
+            ${{ steps.chdb.outputs.directory }}/lib/libchdb.*
+            ${{ steps.chdb.outputs.directory }}/include/chdb.h
       - name: Generate compile_commands.json
         run: make compile_commands.json
       - name: Lint the Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,32 +9,31 @@ jobs:
     name: Release on GitHub and PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
-    env: { pg: 19, chdb_version: 26.7.0 }
+    env: { pg: 19, BUNDLE_LIBCHDB: 1 }
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
         with: { submodules: recursive }
       - name: Start Postgres
         run: pg-start ${{ env.pg }} libkrb5-dev
-      - name: Tweak Permissions # for cache restore
-        run: sudo chmod a+rwx /usr/local/lib /usr/local/include
+      # make BUNDLE_LIBCHDB=1 installs libchdb if missing.
+      - name: Get chDB Version
+        id: chdb
+        run: make libchdb-variables >> $GITHUB_OUTPUT
       - name: Cache chDB
         id: cache-chdb
         uses: actions/cache@v6
         with:
-          key: chdb-${{ env.chdb_version }}-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ steps.chdb.outputs.directory }}
           path: |
-            /usr/local/lib/libchdb.so
-            /usr/local/include/chdb.*
-      - name: Install chDB
-        run: ${{ steps.cache-chdb.outputs.cache-hit != 'true' && 'curl -sL https://lib.chdb.io | sudo -E bash' || 'sudo ldconfig' }}
-        env: { INSTALL_VERSION: "${{ env.chdb_version }}" }
-      - run: sudo chmod +r /usr/local/include/chdb.*
+            ${{ steps.chdb.outputs.directory }}/lib/libchdb.*
+            ${{ steps.chdb.outputs.directory }}/include/chdb.h
       - name: Bundle the Release
         id: bundle
         run: pgxn-bundle
-      # - name: Test the Bundle
-      #   run: make dist-test
+      - name: Test the Bundle
+        env: { TAP_TESTS: "" }
+        run: make dist-test
       - name: Release on PGXN
         if: startsWith( github.ref, 'refs/tags/v' )
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ log/
 /tmp_check/
 *.tmp
 .DS_Store
+/vendor/libchdb-*

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,6 @@ EXTVERSION   = $(shell grep -m 1 'default_version' chdb.control | \
 DISTVERSION  = $(shell grep -m 1 '^[[:space:]]\{2\}"version":' META.json | \
                sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",\{0,1\}/\1/')
 
-# Header-only dependencies, vendored as submodules. clickhouse-c comes from
-# pg-clickhouse-c's own pin, its signatures naming clickhouse-c types, so a
-# second checkout on the include path would silently win.
-PGCH_DIR     = $(CURDIR)/vendor/pg-clickhouse-c
-CH_C_DIR     = $(PGCH_DIR)/clickhouse-c
-
 DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql)
 DOCS         = $(wildcard doc/*.md)
 TESTS        ?= $(wildcard test/sql/*.sql)
@@ -18,11 +12,21 @@ REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 MODULE_big   = $(EXTENSION)
 PG_CONFIG   ?= pg_config
 TAP_TESTS   ?= 1
+OBJS 		 = $(subst .c,.o, $(wildcard src/*.c))
 
 CLANG_FORMAT ?= clang-format
 
-# Collect all the C files to compile into MODULE_big.
-OBJS = $(subst .c,.o, $(wildcard src/*.c))
+# Version of libchdb to bundle.
+LIBCHDB_VERSION = v26.7.0
+
+# Header-only dependencies, vendored as submodules. clickhouse-c comes from
+# pg-clickhouse-c's own pin, its signatures naming clickhouse-c types, so a
+# second checkout on the include path would silently win.
+PGCH_DIR     = $(CURDIR)/vendor/pg-clickhouse-c
+CH_C_DIR     = $(PGCH_DIR)/clickhouse-c
+
+# Downloaded copy of libchdb.
+LIBCHDB_DIR = vendor/libchdb
 
 # Suppress annoying pre-c99 warning, error on 	/other warnings.
 PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
@@ -43,6 +47,16 @@ include $(PGXS)
 # Set default prove flags.
 ifeq ($(PROVE_FLAGS),)
 PROVE_FLAGS = -fwvj $(shell nproc)
+endif
+
+# Build against, install, uninstall a local copy of libchdb.
+ifneq ($(BUNDLE_LIBCHDB),)
+OS         ?= $(shell uname -s | tr A-Z a-z)
+ARCH        = $(shell uname -m)
+LIBCHDB_DIR = vendor/libchdb-$(OS)-$(ARCH)
+src/helper/chdb_helper: $(LIBCHDB_DIR)/lib/libchdb.so
+install: install-libchdb
+uninstall: uninstall-libchdb
 endif
 
 # Require the versioned SQL script.
@@ -80,7 +94,7 @@ $(CH_C_DIR)/clickhouse.h: .gitmodules
 
 # The only program linking libchdb, kept beside the library that starts it.
 src/helper/chdb_helper: $(wildcard src/helper/*.c) src/setup.h
-	@$(MAKE) -C $(dir $@) all
+	@$(MAKE) -C $(dir $@) all LIBCHDB_DIR=$(LIBCHDB_DIR)
 
 # Install the helper. Write beside the live copy and rename over it: install
 # unlinks its target first, so a COPY starting in that moment finds no helper.
@@ -99,6 +113,28 @@ test/schedule:
 	@echo $(schedule) > $@
 
 installcheck: test/schedule
+
+# libchdb
+$(LIBCHDB_DIR)/lib/libchdb.so: vendor/get-libchdb.sh
+	@env INSTALL_VERSION="$(LIBCHDB_VERSION)" DESTDIR=$(LIBCHDB_DIR) bash vendor/get-libchdb.sh
+
+$(LIBCHDB_DIR)/lib/libchdb.a: vendor/get-libchdb.sh
+	env INSTALL_VERSION="$(LIBCHDB_VERSION)" DESTDIR=$(LIBCHDB_DIR) STATIC=1 bash vendor/get-libchdb.sh
+
+# GitHub stuff.
+libchdb-version:
+	@echo $(LIBCHDB_VERSION)
+libchdb-variables:
+	@echo VERSION=$(LIBCHDB_VERSION)
+	@echo DIRECTORY=$(LIBCHDB_DIR)
+
+# Install and uninstall libchdb, which is configured to live in /usr/local/lib.
+install-libchdb: $(LIBCHDB_DIR)/lib/libchdb.so
+	$(MKDIR_P) $(DESTDIR)/usr/local/lib
+	$(INSTALL_SHLIB) $< $(DESTDIR)/usr/local/lib
+	if [ "$$(uname -s)" = "Linux" ]; then ldconfig; fi
+uninstall-libchdb:
+	rm -f $(DESTDIR)/usr/local/lib/libchdb.so
 
 .PHONY: format # Format .c and .h files to project standard in .clang-format.
 format: $(wildcard src/*.c src/*.h src/helper/*.c)
@@ -131,7 +167,7 @@ debian-install-lint:
 dist-test: $(EXTENSION)-$(DISTVERSION).zip
 	unzip $(EXTENSION)-$(DISTVERSION).zip
 	cd $(EXTENSION)-$(DISTVERSION)
-	make && make install && make installcheck
+	$(MAKE) && $(MAKE) install && $(MAKE) installcheck
 
 .PHONY: release-notes # Show release notes for current version (must have `mknotes` in PATH).
 release-notes: CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ shell script:
 curl -sL https://lib.chdb.io | bash
 ```
 
+On Linux, you can also have the installation process download and install it
+by setting `export BUNDLE_LIBCHDB=1` before running the
+[Installation](#installation) `make` commands
+
 Installation
 ------------
 

--- a/src/helper/Makefile
+++ b/src/helper/Makefile
@@ -1,8 +1,13 @@
 PROGRAM  = chdb_helper
-OBJS     = chdb_helper.o
+OBJS     = $(PROGRAM).o
 # override, so a CFLAGS on the command line adds to the project flags.
 override CFLAGS  += -Wall -Werror -O2
 override LDLIBS  += -lchdb
+
+ifneq ($(LIBCHDB_DIR),)
+override LDFLAGS += -L../../$(LIBCHDB_DIR)/lib
+override CFLAGS  += -I../../$(LIBCHDB_DIR)/include
+endif
 
 all: $(PROGRAM)
 

--- a/src/hook/Makefile
+++ b/src/hook/Makefile
@@ -9,7 +9,6 @@ PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
 # default, so match chdb_capture_error's buffer. native.c asserts the pairing.
 PG_CPPFLAGS  = -isystem $(CH_C_DIR) -isystem $(PGCH_DIR) -DPGCH_MSG_PREFIX='"chdb: "' \
                -DCHC_ERR_MSG_LEN=4096
-PG_LDFLAGS   = -lchdb
 PG_CONFIG   ?= pg_config
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/vendor/get-libchdb.sh
+++ b/vendor/get-libchdb.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Based on
+# https://github.com/chdb-io/chdb-io.github.io/blob/main/install_libchdb.sh
+#
+# Environment variables:
+#
+# INSTALL_VERSION: Version to install; defaults to latest release
+# DESTDIR: Directory in which to install; defaults to /usr/local
+# STATIC: If true, install the static library and not the dynamic
+
+set -e
+
+# Check for necessary tools
+command -v curl >/dev/null 2>&1 || { echo >&2 "curl is required but it's not installed. Aborting."; exit 1; }
+command -v tar >/dev/null 2>&1 || { echo >&2 "tar is required but it's not installed. Aborting."; exit 1; }
+
+# Function to download and extract the file
+download_and_extract() {
+    local url="$1"
+    local file="libchdb.tar.gz"
+
+    echo "Attempting to download $file from $url"
+
+    # Download the file with a retry logic
+    if curl -L -o "$file" "$url"; then
+        echo "Download successful."
+
+        # Optional: Verify download integrity here, if checksums are provided
+
+        # Untar the file
+        if tar -xzf "$file"; then
+            rm libchdb.tar.gz
+            echo "Extraction successful."
+            return 0
+        fi
+    fi
+    return 1
+}
+
+INSTALL_VERSION="${INSTALL_VERSION:-$(curl --silent "https://api.github.com/repos/chdb-io/chdb-core/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')}"
+
+# Select the correct package based on OS and architecture
+case "$(uname -s)" in
+    Linux)
+        OS=linux
+        if [[ $(uname -m) == "aarch64" ]]; then
+            ARCH=aarch64
+        else
+            ARCH=x86_64
+        fi
+        ;;
+    Darwin)
+        OS=macos
+        if [[ $(uname -m) == "arm64" ]]; then
+            ARCH=arm64
+        else
+            ARCH=x86_64
+        fi
+        ;;
+    *)
+        echo "Unsupported platform"
+        exit 1
+        ;;
+esac
+
+FILE="${OS}-${ARCH}-libchdb"
+if [ -n "$STATIC" ]; then
+    FILE+=-static
+fi
+
+# Main download URL
+DOWNLOAD_URL="https://github.com/chdb-io/chdb-core/releases/download/$INSTALL_VERSION/$FILE.tar.gz"
+FALLBACK_URL="https://github.com/chdb-io/chdb-core/releases/latest/download/$FILE.tar.gz"
+
+# Try the main download URL first
+if ! download_and_extract "$DOWNLOAD_URL"; then
+    echo "Retrying with fallback URL..."
+    if ! download_and_extract "$FALLBACK_URL"; then
+        echo "Both primary and fallback downloads failed. Aborting."
+        exit 1
+    fi
+fi
+
+DESTDIR="${DESTDIR:-/usr/local}"
+
+# Make sure the library and header directory exists
+mkdir -p "${DESTDIR}/lib" || true
+/bin/cp libchdb.* "${DESTDIR}/lib/"
+if [ -z "$STATIC" ]; then
+    mkdir -p "${DESTDIR}/include" || true
+    /bin/cp chdb.h* "${DESTDIR}/include/"
+else
+    # Set execute permission for libchdb.so and update the library cache
+    chmod +x "${DESTDIR}/lib/libchdb.so"
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        ldconfig
+    fi
+fi
+
+# Clean up
+rm -f libchdb.* chdb.h*
+printf 'Installed into %s\n' "$DESTDIR"


### PR DESCRIPTION
It will be useful for some packagers to bundle `libchdb.so` into an installation package.

Borrow from the lib.chdb.io install script to make a download script that can get either the dynamic or static library and put it into a specified directory.

Add the `BUNDLE_LIBCHDB` variable to the `Makefile`. When it's set, it will download the libchdb to the vendor directory for the current OS and architecture, add that directory to the build variables, and add a target for the install and uninstall targets to install in or uninstall it from `/usr/local`, for which its `rpath` is encoded.

Update the workflows to use the targets and cache the results instead of installing chDB into and caching it from `/usr/local`. Also restore running the pg_regress tests in `release.yml`, only disabling the TAP tests.

Note this feature in the README. Remove `-lchdb` from `src/hook/Makefile`, as only the helper app depends on the library.