### PR TITLE
Support statically compiling libchdb into helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
       matrix:
         pg: [19, 18, 17, 16]
         arch: [amd64, arm64]
-    name: 🐘 PostgreSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }}
+        build: [dynamic, static]
+    name: 🐘 PgSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }} ${{ matrix.build }}
     runs-on: ubuntu-${{ matrix.arch == 'amd64' && 'latest' || '24.04-arm' }}
-    env: { BUNDLE_LIBCHDB: 1 }
+    env: { BUNDLE_LIBCHDB: 1, LIBCHDB_BUILD: "${{ matrix.build }}" }
     services:
       kv-rest:
         image: ghcr.io/theory/kv-rest
@@ -39,14 +40,14 @@ jobs:
         id: cache-chdb
         uses: actions/cache@v6
         with:
-          key: ${{ steps.chdb.outputs.directory }}
+          key: ${{ steps.chdb.outputs.directory }}-${{ matrix.build }}
           path: |
             ${{ steps.chdb.outputs.directory }}/lib/libchdb.*
             ${{ steps.chdb.outputs.directory }}/include/chdb.h
       - name: Build
         run: make -j $(nproc)
       - name: Install
-        run: sudo --preserve-env=BUNDLE_LIBCHDB make install
+        run: sudo --preserve-env=BUNDLE_LIBCHDB,LIBCHDB_BUILD make install
       - name: Configure AWS credentials # for s3.sql round-trip test
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,17 @@ OBJS 		 = $(subst .c,.o, $(wildcard src/*.c))
 
 CLANG_FORMAT ?= clang-format
 
-# Version of libchdb to bundle.
-LIBCHDB_VERSION = v26.7.0
+# Binary dependency on specific version (for now) of libchdb. Optionally
+# download locally by setting BUNDLE_LIBCHDB and compile statically with
+# LIBCHDB_BUILD=static.
+LIBCHDB_VERSION ?= v26.7.0
+LIBCHDB_BUILD   ?= dynamic
 
 # Header-only dependencies, vendored as submodules. clickhouse-c comes from
 # pg-clickhouse-c's own pin, its signatures naming clickhouse-c types, so a
 # second checkout on the include path would silently win.
 PGCH_DIR     = $(CURDIR)/vendor/pg-clickhouse-c
 CH_C_DIR     = $(PGCH_DIR)/clickhouse-c
-
-# Downloaded copy of libchdb.
-LIBCHDB_DIR = vendor/libchdb
 
 # Suppress annoying pre-c99 warning, error on 	/other warnings.
 PG_CFLAGS    = -Wno-declaration-after-statement -Wall -Werror
@@ -54,7 +54,7 @@ ifneq ($(BUNDLE_LIBCHDB),)
 OS         ?= $(shell uname -s | tr A-Z a-z)
 ARCH        = $(shell uname -m)
 LIBCHDB_DIR = vendor/libchdb-$(OS)-$(ARCH)
-src/helper/chdb_helper: $(LIBCHDB_DIR)/lib/libchdb.so
+src/helper/chdb_helper: $(LIBCHDB_DIR)/lib/libchdb.$(if $(filter $(LIBCHDB_BUILD),static),a,so)
 install: install-libchdb
 uninstall: uninstall-libchdb
 endif
@@ -94,7 +94,7 @@ $(CH_C_DIR)/clickhouse.h: .gitmodules
 
 # The only program linking libchdb, kept beside the library that starts it.
 src/helper/chdb_helper: $(wildcard src/helper/*.c) src/setup.h
-	@$(MAKE) -C $(dir $@) all LIBCHDB_DIR=$(LIBCHDB_DIR)
+	@$(MAKE) -C $(dir $@) all LIBCHDB_DIR=$(LIBCHDB_DIR) LIBCHDB_BUILD=$(LIBCHDB_BUILD)
 
 # Install the helper. Write beside the live copy and rename over it: install
 # unlinks its target first, so a COPY starting in that moment finds no helper.
@@ -115,10 +115,10 @@ test/schedule:
 installcheck: test/schedule
 
 # libchdb
-$(LIBCHDB_DIR)/lib/libchdb.so: vendor/get-libchdb.sh
+$(LIBCHDB_DIR)/lib/libchdb.so:
 	@env INSTALL_VERSION="$(LIBCHDB_VERSION)" DESTDIR=$(LIBCHDB_DIR) bash vendor/get-libchdb.sh
 
-$(LIBCHDB_DIR)/lib/libchdb.a: vendor/get-libchdb.sh
+$(LIBCHDB_DIR)/lib/libchdb.a:
 	env INSTALL_VERSION="$(LIBCHDB_VERSION)" DESTDIR=$(LIBCHDB_DIR) STATIC=1 bash vendor/get-libchdb.sh
 
 # GitHub stuff.
@@ -129,12 +129,12 @@ libchdb-variables:
 	@echo DIRECTORY=$(LIBCHDB_DIR)
 
 # Install and uninstall libchdb, which is configured to live in /usr/local/lib.
-install-libchdb: $(LIBCHDB_DIR)/lib/libchdb.so
+install-libchdb: $(LIBCHDB_DIR)/lib/libchdb.$(if $(filter $(LIBCHDB_BUILD),static),a,so)
 	$(MKDIR_P) $(DESTDIR)/usr/local/lib
 	$(INSTALL_SHLIB) $< $(DESTDIR)/usr/local/lib
 	if [ "$$(uname -s)" = "Linux" ]; then ldconfig; fi
 uninstall-libchdb:
-	rm -f $(DESTDIR)/usr/local/lib/libchdb.so
+	rm -f $(DESTDIR)/usr/local/lib/libchdb.$(if $(filter $(LIBCHDB_BUILD),static),a,so)
 
 .PHONY: format # Format .c and .h files to project standard in .clang-format.
 format: $(wildcard src/*.c src/*.h src/helper/*.c)

--- a/README.md
+++ b/README.md
@@ -122,16 +122,26 @@ Dependencies
 ------------
 
 The `chdb` extension requires PostgreSQL 16 or higher and the [chDB] library
-v26.7.0 or greater. The simplest way to install it is via the [lib.chdb.io]
-shell script:
+v26.7.0 or greater (currently available only for Linux and macOS). The
+simplest way to install it is via the [lib.chdb.io] shell script:
 
 ```sh
 curl -sL https://lib.chdb.io | bash
 ```
 
-On Linux, you can also have the installation process download and install it
-by setting `export BUNDLE_LIBCHDB=1` before running the
-[Installation](#installation) `make` commands
+To statically compile [chDB] into the helper app, set the following variables
+before running the [Installation](#installation) `make` commands.
+
+```sh
+export BUNDLE_LIBCHDB=1 LIBCHDB_BUILD=static
+```
+
+The `Makefile` will download the static `libchdb` library and compile it into
+the app.
+
+On Linux, you can also have the installation process download and install the
+dynamic `libchdb` library by setting `export BUNDLE_LIBCHDB=1` before running
+the [Installation](#installation) `make` commands.
 
 Installation
 ------------

--- a/src/helper/Makefile
+++ b/src/helper/Makefile
@@ -2,11 +2,31 @@ PROGRAM  = chdb_helper
 OBJS     = $(PROGRAM).o
 # override, so a CFLAGS on the command line adds to the project flags.
 override CFLAGS  += -Wall -Werror -O2
-override LDLIBS  += -lchdb
 
 ifneq ($(LIBCHDB_DIR),)
-override LDFLAGS += -L../../$(LIBCHDB_DIR)/lib
-override CFLAGS  += -I../../$(LIBCHDB_DIR)/include
+    override LIBCHDB_DIR := ../../$(LIBCHDB_DIR)
+    override LDFLAGS += -L$(LIBCHDB_DIR)/lib
+    override CFLAGS  += -I$(LIBCHDB_DIR)/include
+else
+    # Default location for chDB library releases.
+    override LIBCHDB_DIR := /usr/local
+endif
+
+ifneq ($(LIBCHDB_BUILD),static)
+    # Link the dynamic library.
+    override LDLIBS  += -lchdb
+else
+    # Static compilation requires extra flags. See the Go builds for details:
+    # https://github.com/chdb-io/chdb-core/tree/main/chdb/build/go-example
+    OS = $(shell uname -s)
+	STATIC_LIB = $(LIBCHDB_DIR)/lib/libchdb.a
+    ifeq ($(OS),Linux)
+        override LDFLAGS += -Wl,--whole-archive $(STATIC_LIB) -Wl,--no-whole-archive -lm -lrt -lpthread -ldl
+    else ifeq ($(OS),Darwin)
+        override LDFLAGS += -mmacosx-version-min=10.15 -Wl,-force_load,$(STATIC_LIB) -liconv -framework CoreFoundation -framework Security
+    else
+        $(error Unsupported OS "$(OS)": libchdb supports only Linux and macOS)
+    endif
 endif
 
 all: $(PROGRAM)

--- a/vendor/get-libchdb.sh
+++ b/vendor/get-libchdb.sh
@@ -84,18 +84,14 @@ fi
 
 DESTDIR="${DESTDIR:-/usr/local}"
 
-# Make sure the library and header directory exists
-mkdir -p "${DESTDIR}/lib" || true
+# Install the library and headers.
+mkdir -p "${DESTDIR}/lib" "${DESTDIR}/include" || true
 /bin/cp libchdb.* "${DESTDIR}/lib/"
+/bin/cp chdb.h* "${DESTDIR}/include/"
+
 if [ -z "$STATIC" ]; then
-    mkdir -p "${DESTDIR}/include" || true
-    /bin/cp chdb.h* "${DESTDIR}/include/"
-else
-    # Set execute permission for libchdb.so and update the library cache
+    # Set execute permission for libchdb.so.
     chmod +x "${DESTDIR}/lib/libchdb.so"
-    if [[ "$(uname -s)" == "Linux" ]]; then
-        ldconfig
-    fi
 fi
 
 # Clean up


### PR DESCRIPTION
Add the `LIBCHDB_BUILD` variable to the build process. When set to `static`, it will configure things to statically compile `libchdb` into the helper app. Best used in combination with `BUNDLE_LIBCHDB=1`, which knows how to download the static library.

Currently it still prefers the `.so` file if it finds it, so make sure it's not around if you want a static compile.

Augment the build matrix in `ci.yml` to compile and test both dynamic and static builds.

Fix issues in `vendor/get-libchdb.sh` properly handling a static library download and document the options in the README.