### PR TITLE
Add support for Postgres 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [19, 18, 17, 16]
+        pg: [19, 18, 17, 16, 15]
         arch: [amd64, arm64]
         build: [dynamic, static]
     name: 🐘 PgSQL ${{ matrix.pg }} ${{ matrix.arch == 'amd64' && '🧰' || '🦾' }} ${{ matrix.arch }} ${{ matrix.build }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. It uses the
 
 *   Support mapping `BFloat16` to Postgres `real`, and `Interval` types to
     Postgres `interval` ([#76]).
+*   Added PostgreSQL 15 support.
 
 ### 🐞 Bug Fixes
 

--- a/META.json
+++ b/META.json
@@ -22,7 +22,7 @@
   "prereqs": {
     "runtime": {
       "requires": {
-        "PostgreSQL": "16.0.0"
+        "PostgreSQL": "15.0.0"
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ leaving other sessions untouched.
 Dependencies
 ------------
 
-The `chdb` extension requires PostgreSQL 16 or higher and the [chDB] library
+The `chdb` extension requires PostgreSQL 15 or higher and the [chDB] library
 v26.7.0 or greater (currently available only for Linux and macOS). The
 simplest way to install it is via the [lib.chdb.io] shell script:
 

--- a/src/hook/hook.c
+++ b/src/hook/hook.c
@@ -169,8 +169,14 @@ open_copy_relation(CopyStmt* copy, chdbCopyContext* ctx) {
     ParseState* pstate = make_parsestate(NULL);
     ParseNamespaceItem* nsitem =
         addRangeTableEntryForRelation(pstate, rel, lockmode, NULL, false, false);
+#if PG_VERSION_NUM >= 160000
     RTEPermissionInfo* perminfo = nsitem->p_perminfo;
     perminfo->requiredPerms     = copy->is_from ? ACL_INSERT : ACL_SELECT;
+#else
+    /* Delete test/expected/permissions_1.out when Postgres 15 dropped. */
+    RangeTblEntry* perminfo = nsitem->p_rte;
+    perminfo->requiredPerms = (copy->is_from ? ACL_INSERT : ACL_SELECT);
+#endif
 
     ctx->rel     = rel;
     ctx->attnums = CopyGetAttnums(RelationGetDescr(rel), rel, copy->attlist);
@@ -183,11 +189,17 @@ open_copy_relation(CopyStmt* copy, chdbCopyContext* ctx) {
         *cols =
             bms_add_member(*cols, lfirst_int(lc) - FirstLowInvalidHeapAttributeNumber);
     }
+#if PG_VERSION_NUM >= 160000
     ExecCheckPermissions(pstate->p_rtable, pstate->p_rteperminfos, true);
+#else
+    ExecCheckRTPerms(pstate->p_rtable, true);
+#endif
 
     /* A COPY FROM hands this to the executor rather than building its own. */
-    ctx->rtable       = pstate->p_rtable;
+    ctx->rtable = pstate->p_rtable;
+#if PG_VERSION_NUM >= 160000
     ctx->rteperminfos = pstate->p_rteperminfos;
+#endif
 
     /*
      * chDB copies the whole relation, so policies cannot be applied to the

--- a/src/native.c
+++ b/src/native.c
@@ -371,8 +371,10 @@ static inline List*
 insert_index_tuples(ResultRelInfo* rri, TupleTableSlot* slot, EState* estate) {
 #if PG_VERSION_NUM >= 190000
     return ExecInsertIndexTuples(rri, estate, 0, slot, NIL, NULL);
-#else
+#elif PG_VERSION_NUM >= 160000
     return ExecInsertIndexTuples(rri, slot, estate, false, false, NULL, NIL, false);
+#else
+    return ExecInsertIndexTuples(rri, slot, estate, false, false, NULL, NIL);
 #endif
 }
 
@@ -679,8 +681,10 @@ chdb_copy_receive(
 
 #if PG_VERSION_NUM >= 180000
     ExecInitRangeTable(estate, rtable, rteperminfos, bms_make_singleton(1));
-#else
+#elif PG_VERSION_NUM >= 160000
     ExecInitRangeTable(estate, rtable, rteperminfos);
+#else
+    ExecInitRangeTable(estate, rtable);
 #endif
     ResultRelInfo* target = makeNode(ResultRelInfo);
 
@@ -802,8 +806,11 @@ chdb_copy_receive(
                 ins.transition->tcs_original_insert_tuple = before_row ? NULL : slot;
             }
 
+#if PG_VERSION_NUM >= 160000
             TupleConversionMap* map = ExecGetRootToChildMap(rri, estate);
-
+#else
+            TupleConversionMap* map = rri->ri_RootToPartitionMap;
+#endif
             if (map) {
                 slot = execute_attr_map_slot(
                     map->attrMap, slot, rri->ri_PartitionTupleSlot

--- a/test/expected/permissions_1.out
+++ b/test/expected/permissions_1.out
@@ -1,0 +1,152 @@
+LOAD 'chdb_hook';
+CREATE TABLE secrets (
+    id     INT  PRIMARY KEY,
+    name   TEXT NOT NULL,
+    secret TEXT NOT NULL
+);
+INSERT INTO secrets VALUES (1, 'alice', 'hunter2'), (2, 'bob', 'letmein');
+CREATE TABLE names (
+    id   INT  PRIMARY KEY,
+    name TEXT NOT NULL,
+    who  TEXT NOT NULL DEFAULT current_user
+);
+-- Clean up after any previous failed run.
+SET client_min_messages = error;
+DROP ROLE IF EXISTS chdb_none;
+DROP ROLE IF EXISTS chdb_reader;
+RESET client_min_messages;
+CREATE ROLE chdb_none;
+CREATE ROLE chdb_reader;
+GRANT SELECT (id, name) ON secrets TO chdb_reader;
+GRANT INSERT (id, name) ON names TO chdb_reader;
+-- Disable quiet to emit COPY numbers
+\set QUIET false
+-- Copy through /tmp, which the server can always read and write.
+\set names_out file:///tmp/permissions.tmp/names.tsv
+-- Copying a server file requires the same role membership as a Postgres COPY.
+SET ROLE chdb_reader;
+SET
+COPY secrets (id, name) TO :'names_out';
+ERROR:  chdb: permission denied to COPY to a file
+DETAIL:  Only roles with privileges of the "pg_write_server_files" role may COPY to a file.
+COPY names (id, name) FROM :'names_out';
+ERROR:  chdb: permission denied to COPY from a file
+DETAIL:  Only roles with privileges of the "pg_read_server_files" role may COPY from a file.
+RESET ROLE;
+RESET
+GRANT pg_read_server_files, pg_write_server_files TO chdb_none, chdb_reader;
+GRANT ROLE
+-- A role without privileges cannot copy the relation.
+SET ROLE chdb_none;
+SET
+COPY secrets TO :'names_out';
+ERROR:  permission denied for table secrets
+COPY secrets FROM :'names_out';
+ERROR:  permission denied for table secrets
+-- Column privileges cover only the copied columns.
+SET ROLE chdb_reader;
+SET
+COPY secrets TO :'names_out';
+ERROR:  permission denied for table secrets
+COPY secrets (id, secret) TO :'names_out';
+ERROR:  permission denied for table secrets
+COPY secrets (id, name) TO :'names_out';
+COPY 2
+-- The copy runs as the role that ran the COPY.
+COPY names (id, name) FROM :'names_out';
+COPY 2
+RESET ROLE;
+RESET
+SELECT * FROM names ORDER BY id;
+ id | name  |     who     
+----+-------+-------------
+  1 | alice | chdb_reader
+  2 | bob   | chdb_reader
+(2 rows)
+
+-- COPY TO PROGRAM remains Postgres's business.
+SET ROLE chdb_reader;
+SET
+COPY names TO PROGRAM 'file:///bin/cat';
+ERROR:  must be superuser or have privileges of the pg_execute_server_program role to COPY to or from an external program
+HINT:  Anyone can COPY to stdout or from stdin. psql's \copy command also works for anyone.
+RESET ROLE;
+RESET
+-- chDB copies every row, so row-level security cannot be applied.
+ALTER TABLE secrets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE
+CREATE POLICY own_secret ON secrets FOR SELECT TO chdb_reader USING (name = current_user);
+CREATE POLICY
+SET ROLE chdb_reader;
+SET
+COPY secrets (id, name) TO :'names_out';
+ERROR:  chdb: COPY TO not supported with row-level security
+DETAIL:  Row-level security policies apply to relation "secrets" for this role.
+SET row_security = off;
+SET
+COPY secrets (id, name) TO :'names_out';
+ERROR:  query would be affected by row-level security policy for table "secrets"
+RESET row_security;
+RESET
+RESET ROLE;
+RESET
+-- The owner bypasses row-level security, so exports every row.
+COPY secrets TO :'names_out';
+COPY 2
+CREATE TABLE exported (LIKE secrets);
+CREATE TABLE
+COPY exported FROM :'names_out';
+COPY 2
+SELECT * FROM exported ORDER BY id;
+ id | name  | secret  
+----+-------+---------
+  1 | alice | hunter2
+  2 | bob   | letmein
+(2 rows)
+
+-- COPY FROM writes, so a read-only transaction rejects it.
+BEGIN READ ONLY;
+BEGIN
+COPY names FROM :'names_out';
+ERROR:  cannot execute COPY FROM in a read-only transaction
+ROLLBACK;
+ROLLBACK
+-- The copy runs in this session, so it sees its temporary relations.
+CREATE TEMP TABLE tmp_names (id INT, name TEXT);
+CREATE TABLE
+COPY names (id, name) TO :'names_out';
+COPY 2
+COPY tmp_names FROM :'names_out';
+COPY 2
+SELECT * FROM tmp_names ORDER BY id;
+ id | name  
+----+-------
+  1 | alice
+  2 | bob
+(2 rows)
+
+-- The copy joins this transaction, so a rollback takes its rows with it.
+BEGIN;
+BEGIN
+COPY tmp_names FROM :'names_out';
+COPY 2
+SELECT count(*) FROM tmp_names;
+ count 
+-------
+     4
+(1 row)
+
+ROLLBACK;
+ROLLBACK
+SELECT count(*) FROM tmp_names;
+ count 
+-------
+     2
+(1 row)
+
+DROP TABLE secrets, names, exported;
+DROP TABLE
+DROP ROLE chdb_none, chdb_reader;
+DROP ROLE
+-- Files belong to the server user, so ignore failure to remove them.
+\! rm -rf /tmp/permissions.tmp 2>/dev/null


### PR DESCRIPTION
Can't support 14 because we need `\getenv` in tests, and it didn't exist then. The changes to permissions in postgres/postgres@a61b1f74823c are a little tricky, and generate a different error message, so we have to add a slightly uncomfortable number of `#if` directives and refer to a RangeTblEntry as `perminfo`, as well as include an alternate expected output, but all tests pass.

This will simplify integration into pg_clickhouse, which currently works on Postgres 13 or later, but will soon drop 13 and perhaps also 14.