### PR TITLE
Add `NO_FILE_SCHEME` option to `make`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,13 @@ jobs:
         with:
           name: regression-diffs-pg${{ matrix.pg }}
           path: regression.diffs
+      - name: Test No File
+        # NO_FILE_SCHEME disables file://; when set, file test should fail
+        # with output that includes "could not open file". This step fails if
+        # the test output does not include that text.
+        run: |
+          (cd src/hook && rm -rf chdb_hook.* hook.o)
+          make -j $(nproc) NO_FILE_SCHEME=1
+          sudo --preserve-env=BUNDLE_LIBCHDB,LIBCHDB_BUILD make install
+          make installcheck TAP_TESTS= TESTS=test/sql/file.sql || true
+          grep -s 'could not open file' regression.diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file. It uses the
 
 ## [v0.1.2] — Unreleased
 
+### 🏗️ Build Setup
+
+*   Added the `NO_FILE_SCHEME` option to `make`. When set, chd_hook will be
+    built without support for the `file://` scheme, which may be useful for
+    Postgres hosting providers.
+
 ### 📚 Documentation
 
 *   Added missing links to the README and docs and simplified the list of

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ src/version.h: META.json
 # Hook module.
 HOOK_MODULE := src/hook/chdb_hook$(DLSUFFIX)
 $(HOOK_MODULE): $(wildcard src/hook/*.c src/hook/*.h) $(OBJS)
-	@$(MAKE) -C $(dir $@) all -j $$(nproc) CH_C_DIR=$(CH_C_DIR) PGCH_DIR=$(PGCH_DIR)
+	@$(MAKE) -C $(dir $@) all -j $$(nproc) CH_C_DIR=$(CH_C_DIR) PGCH_DIR=$(PGCH_DIR) NO_FILE_SCHEME=$(NO_FILE_SCHEME)
 
 # Install and uninstall the chdb_hook module.
 install-hook: $(HOOK_MODULE)

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ You need to run the test suite using a super user, such as the default
 make installcheck PGUSER=postgres
 ```
 
+To disable the `file://` scheme in the `COPY` hook, define `NO_FILE_SCHEME`:
+
+```sh
+make NO_FILE_SCHEME=1
+```
+
 To install the extension in a custom prefix on PostgreSQL 18 or later, pass
 the `prefix` argument to `install` (but no other `make` targets):
 

--- a/doc/chdb_hook.md
+++ b/doc/chdb_hook.md
@@ -121,6 +121,11 @@ The format of URLs varies by the target.
 
 #### File
 
+> [!IMPORTANT]
+> The `file://` scheme may not be supported on all systems, such as cloud
+> platforms, where the administrator compiles `chdb_hook` to prevent it (via
+> the `NO_FILE_SCHEME` option to `make`).
+
 Must be an absolute path on the Postgres server. A relative path results in an
 error. The Postgres user must be a member of the `pg_read_server_files` or
 `pg_write_server_files` role, as appropriate. The Postgres system user must

--- a/src/hook/Makefile
+++ b/src/hook/Makefile
@@ -11,6 +11,11 @@ PG_CPPFLAGS  = -isystem $(CH_C_DIR) -isystem $(PGCH_DIR) -DPGCH_MSG_PREFIX='"chd
                -DCHC_ERR_MSG_LEN=4096
 PG_CONFIG   ?= pg_config
 
+# Define CHDB_NO_FILE_SCHEME to disable the chdb_hook file:// scheme.
+ifneq ($(NO_FILE_SCHEME),)
+PG_CPPFLAGS += -DCHDB_NO_FILE_SCHEME=1
+endif
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/src/hook/copy.h
+++ b/src/hook/copy.h
@@ -15,8 +15,8 @@ typedef enum scheme {
     gcs_scheme,
     az_scheme,
     abfs_scheme,
-    file_scheme,
     hdfs_scheme,
+    file_scheme,
     no_scheme, /* Must be last.*/
 } scheme;
 

--- a/src/hook/hook.c
+++ b/src/hook/hook.c
@@ -34,6 +34,16 @@ PG_MODULE_MAGIC_EXT(.name = "chdb_hook", .version = PGCHCB_VERSION);
 PG_MODULE_MAGIC;
 #endif
 
+/*
+ * Remove file_scheme if CHDB_NO_FILE_SCHEME is defined. Works because the
+ * `scheme_for()` considers only schemes < `CHDB_NO_SCHEME`.
+ */
+#ifdef CHDB_NO_FILE_SCHEME
+#define CHDB_NO_SCHEME file_scheme
+#else
+#define CHDB_NO_SCHEME no_scheme
+#endif
+
 void
 InitializeUtilityHook(void);
 
@@ -109,7 +119,7 @@ scheme_for(const char* str) {
         if (ptr) {
             size_t len = ptr - str;
 
-            for (size_t sch = http_scheme; sch < no_scheme; sch++) {
+            for (size_t sch = http_scheme; sch < CHDB_NO_SCHEME; sch++) {
                 for (size_t i = 0; scheme_name[sch][i]; i++) {
                     if (strlen(scheme_name[sch][i]) == len &&
                         memcmp(str, scheme_name[sch][i], len) == 0) {


### PR DESCRIPTION
This option adds a constant to the compilation of the helper that disables recognition of the `file://` schema in `chdb_hook`. Useful for environments in which users should not be able to access the file system, such as cloud platforms.

Users can still use `chdb_query('SELECT * FROM file(...)')` to access the file system; that control will need to be locked down by other means.